### PR TITLE
Remove Feedafever

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,6 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 * [Deltafeed](http://bitreading.com/deltafeed)
 * [DiggReader](http://digg.com/login?next=%2Freader)
 * [Feed43](http://feed43.com)
-* [Feedafever](http://www.feedafever.com)
 * [FeedBooster](http://www.qsensei.com)
 * [Feederator](http://www.feederator.org)
 * [Feed Exileed](http://feed.exileed.com)


### PR DESCRIPTION
Developer of Fever shut it down // No longer a thing.

https://shauninman.com/archive/2016/12/24/goodbye_mint_goodbye_fever / https://feedafever.com/