### PR TITLE
Remove Plancake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1957,7 +1957,6 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 * [Pinstriped](http://pinstriped.com)
 * [PivotalTracker](http://www.pivotaltracker.com)
 * [Plan](https://plan.io)
-* [Plancake](http://www.plancake.com)
 * [Planleaf](http://www.planleaf.com)
 * [Planzone](https://www.planzone.com)
 * [Podio](https://podio.com)


### PR DESCRIPTION
Website is no longer around / URL is dead. http://www.plancake.com