### PR TITLE
Remove Yomapic, Insta-Earth, and TeachingPrivacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,15 +406,12 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 * [Hashtagify](http://hashtagify.me)
 * [Iconosquare](http://iconosquare.com)
 * [Ink361](http://ink361.com)
-* [Insta-earth](http://instaearth.me)
 * [Picodash](https://www.picodash.com)
 * [SnapMap](https://snapmap.knightlab.com/)
 * [Social Rank](https://www.socialrank.com)
-* [TeachingPrivacy](http://app.teachingprivacy.com)
 * [Tofo.me](https://tofo.me)
 * [Websta (Instagram)](http://websta.me)
 * [Worldcam](http://worldc.am)
-* [Yomapic](http://www.yomapic.com)
 
 ### [↑](#table-of-contents) Pinterest
 


### PR DESCRIPTION
From Instagram category.

URLs are dead / Websites do not resolve.