### PR TITLE
Remove Yomapic from VK section

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,6 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 * [VK Parser](http://vkparser.ru)
 * [VK People Search](http://vk.com/people)
 * [VK to RSS Appspot](http://vk-to-rss.appspot.com)
-* [Yomapic](http://www.yomapic.com)
 
 ### [↑](#table-of-contents) Tumblr
 


### PR DESCRIPTION
Website is no longer around / URL does not resolve.