### PR TITLE
Add Calculist to List of Note Taking Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,6 +1428,7 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 
 ## [↑](#contents) Note-taking
 
+* [Calculist](https://app.calculist.io/)
 * [Cherrytree](http://www.giuspen.com/cherrytree)
 * [Evernote](https://www.evernote.com)
 * [Fetchnotes](http://www.fetchnotes.com)

--- a/README.md
+++ b/README.md
@@ -1428,7 +1428,6 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 
 ## [↑](#contents) Note-taking
 
-* [Calculist](https://app.calculist.io/)
 * [Cherrytree](http://www.giuspen.com/cherrytree)
 * [Evernote](https://www.evernote.com)
 * [Fetchnotes](http://www.fetchnotes.com)
@@ -1446,6 +1445,7 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 * [Tomboy](https://wiki.gnome.org/Apps/Tomboy)
 * [Workflowy](https://workflowy.com)
 * [wridea](http://wridea.com)
+* [Calculist](https://app.calculist.io/)
 
 ## [↑](#contents) Annotation Tools
 


### PR DESCRIPTION
Add Calculist to the list of note taking software.

Purpose:
From its webpage: Calculist is an open-source thinking tool. It's sort of like a spreadsheet app with a tree data structure.