### PR TITLE
Add link to explanation on WikiPedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [<img src="https://github.com/jivoi/awesome-osint/raw/master/osint_logo.png" align="right" width="100">](https://github.com/jivoi/awesome-osint)
 
 A curated list of amazingly awesome open source intelligence tools and resources.
-Open-source intelligence (OSINT) is intelligence collected from publicly available sources.
+[Open-source intelligence (OSINT)](https://en.wikipedia.org/wiki/Open-source_intelligence) is intelligence collected from publicly available sources.
 In the intelligence community (IC), the term "open" refers to overt, publicly available sources (as opposed to covert or clandestine sources)
 
 ## Contents


### PR DESCRIPTION
I think, Wikipedia is a good place for further information. To make it easier for newcomers, I put a direct link to https://en.wikipedia.org/wiki/Open-source_intelligence into the introduction.