### PR TITLE
Removing powered-by-Bing sites 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,7 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 
 * [All-in-One](http://all-io.net)
 * [AllTheInternet](http://www.alltheinternet.com)
-* [Dogpile](http://www.dogpile.com)
 * [Etools](http://www.etools.ch)
-* [Excite](http://msxml.excite.com)
 * [FaganFinder](http://www.faganfinder.com/engines)
 * [Glearch](http://www.glearch.com)
 * [Goofram](http://www.goofram.com)
@@ -163,7 +161,6 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 * [Qwant](http://www.qwant.com)
 * [Sputtr](http://www.sputtr.com)
 * [Trovando](http://www.trovando.it)
-* [WebCrawler](http://www.webcrawler.com)
 * [WiinkZ](http://www.wiinkz.com)
 * [Zapmeta](http://www.zapmeta.com)
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,10 @@ This list was taken directly from [i-inteligence's](http://www.i-intelligence.eu
 * [Better Search](https://chrome.google.com/webstore/detail/better-search/ipicopkjbiphdmegamfkeieghhmcjema)
 * [Dothop](http://dothop.com)
 * [DuckDuckGo](https://duckduckgo.com) - an Internet search engine that emphasizes protecting searchers' privacy.
-* [Excite](http://www.excite.com)
 * [Factbites](http://www.factbites.com)
 * [Gigablast](http://gigablast.com)
 * [Goodsearch](http://www.goodsearch.com)
 * [Google Search](http://www.google.com) - Most popular search engine.
-* [Info.com](http://www.info.com)
-* [Infospace](http://www.infospace.com)
 * [Instya](http://www.instya.com)
 * [Impersonal.me](http://www.impersonal.me)
 * [iSEEK Education](http://education.iseek.com/iseek/home.page)


### PR DESCRIPTION
Info, Infospace and Excite repackage the Bing search feed with extra ads - I recommend removing them from the list.