### PR TITLE
Addition to Newsletter Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1463,6 +1463,7 @@ Thanks to our main contributors
 * [Sendicate](https://www.sendicate.net)
 * [Sendloop](https://sendloop.com)
 * [Signupto](https://www.signupto.com)
+* [SpiceSend](http://spicesend.com)
 * [TinyLetter](http://tinyletter.com)
 * [VerticalResponse](http://www.verticalresponse.com)
 * [Vision6](http://www.vision6.com.au)


### PR DESCRIPTION
Hey,
Can you  add  spicesend to the list of "Newsletter Tools"
* [SpiceSend](http://spicesend.com)
been using it for it more than a month now for my free emailing.