### PR TITLE
Add Telegago

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ algorithms, knowledgebase and AI technology.
 
 ### [↑](#contents) Telegram
 
-* [Telegago](https://bit.ly/telegago) - A Google Advanced Search specifically for finding public and private Telegram Channels and Chatrooms. 
+* [Telegago](https://cse.google.com/cse?cx=006368593537057042503:efxu7xprihg#gsc.tab=0) - A Google Advanced Search specifically for finding public and private Telegram Channels and Chatrooms. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In the intelligence community (IC), the term "open" refers to overt, publicly av
    - [VKontakte](#-vkontakte)
    - [Tumblr](#-tumblr)
    - [LinkedIn](#-linkedin)
+   - [Telegram] (#-telegram)
  - [Blog Search](#-blog-search)
  - [Forums and Discussion Boards Search](#-forums-and-discussion-boards-search)
  - [Username Check](#-username-check)
@@ -443,6 +444,13 @@ algorithms, knowledgebase and AI technology.
 ### [↑](#contents) LinkedIn
 
 * [FTL](https://chrome.google.com/webstore/detail/ftl/lkpekgkhmldknbcgjicjkomphkhhdkjj?hl=en-GB) - Browser plugin that finds emails of people's profiles in LinkedIn.
+
+
+### [↑](#contents) Telegram
+
+* [Telegago](https://bit.ly/telegago) - A Google Advanced Search specifically for finding public and private Telegram Channels and Chatrooms. 
+
+
 
 ## [↑](#contents) Blog Search
 


### PR DESCRIPTION
Adding Telegago, a Google CSE specifically for  public and private Telegram Channels.