### PR TITLE
Canva - digital publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1433,7 +1433,6 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#contents) Digital Publishing
 
-* [Canva](https://www.canva.com)
 * [Doclayer](https://standaert.net/doclayer)
 * [Issuu](https://issuu.com)
 * [Lucidpress](https://www.lucidpress.com)


### PR DESCRIPTION
removed, canva is listed 4 times on this list in different sections, not necessarily correct.