### PR TITLE
Add GitGuardian Public GitHub Monitoring to the Threat Intelligence category

### DIFF
--- a/README.md
+++ b/README.md
@@ -2180,6 +2180,7 @@ urls and other data effortlessly
 
 ## [↑](#contents) Threat Intelligence
 
+* [GitGuardian - Public GitHub Monitoring](https://www.gitguardian.com/monitor-public-github-for-secrets) - Monitor public GitHub repositories in real time. Detect secrets and sensitive information to prevent hackers from using GitHub as a backdoor to your business.
 * [REScure Threat Intel Feed](https://rescure.fruxlabs.com/) - REScure is an independent threat intelligence project which we undertook to enhance our understanding of distributed systems, their integration, the nature of threat intelligence and how to efficiently collect, store, consume, distribute it.
 * [OTX AlienVault](https://otx.alienvault.com/) - Open Threat Exchange is the neighborhood watch of the global intelligence community. It enables private companies, independent security researchers, and government agencies to openly collaborate and share the latest information about emerging threats, attack methods, and malicious actors, promoting greater security across the entire community.
 * [OnionScan](https://github.com/s-rah/onionscan) - Free and open source tool for investigating the Dark Web. Its main goal is to help researchers and investigators monitor and track Dark Web sites.


### PR DESCRIPTION
GitGuardian is helping developers and security teams secure software development with automated secrets detection for private or public source code - https://www.gitguardian.com/monitor-public-github-for-secrets.