### PR TITLE
Remove Metta.io (domain parked).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1579,7 +1579,6 @@ algorithms, knowledgebase and AI technology.
 * [Interlude](https://interlude.fm)
 * [Klynt](http://www.klynt.net)
 * [MakeBeliefsComix](http://www.makebeliefscomix.com)
-* [Metta](http://www.metta.io)
 * [Neatline](http://neatline.org)
 * [Odyssey](https://cartodb.github.io/odyssey.js)
 * [Pageflow](http://pageflow.io)


### PR DESCRIPTION
Explanation in title; appears that the service no longer exists at the linked domain.