### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,14 @@ Thanks to our main contributors
 * [Ask](http://www.ask.com)
 * [Bing](http://www.bing.com)
 * [DuckDuckGo](https://duckduckgo.com) - an Internet search engine that emphasizes protecting searchers' privacy.
-* [Gigablast](http://gigablast.com)
-* [Goodsearch](http://www.goodsearch.com)
+* [Gigablast](http://gigablast.com) - provides large-scale, high-performance, real-time information retrieval technology and services for partner sites. 
+* [Goodsearch](http://www.goodsearch.com) - a search engine for shopping deals online.
 * [Google Search](http://www.google.com) - Most popular search engine.
 * [Instya](http://www.instya.com)
 * [Impersonal.me](http://www.impersonal.me)
-* [ixquick](https://www.ixquick.com)
 * [Lycos](http://www.lycos.com)
 * [Search.com](http://www.search.com)
-* [SurfCanyon](http://www.surfcanyon.com)
-* [Teoma](http://www.teoma.com) - Teoma (from Scottish Gaelic teòma "expert") was an Internet search engine founded in April 2000 by Professor Apostolos Gerasoulis and his colleagues at Rutgers University in New Jersey.
+* [SurfCanyon](http://www.surfcanyon.com) - a real-time contextual search technology that observes user behavior in order to disambiguate intent "on the fly," and then automatically bring forward to page one relevant results that might otherwise have remain buried.
 * [Wolfram Alpha](http://www.wolframalpha.com) - Wolfram Alpha is a computational knowledge engine (answer engine) developed by Wolfram Alpha. It will compute expert-level answers using Wolfram’s breakthrough
 algorithms, knowledgebase and AI technology.
 * [Yahoo! Search](http://www.yahoo.com)


### PR DESCRIPTION
REMOVED

* [Teoma](http://www.teoma.com) - Teoma (from Scottish Gaelic teòma "expert") was an Internet search engine founded in April 2000 by Professor Apostolos Gerasoulis and his colleagues at Rutgers University in New Jersey.
* [ixquick](https://www.ixquick.com)

No longer websites or projects

ADDED

Descriptions to a few of the General Search websites.