### PR TITLE
Update `Visual Search and Clustering Search Engines` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ algorithms, knowledgebase and AI technology.
 * [iZito](http://www.izito.com)
 * [Myallsearch](http://www.myallsearch.com)
 * [Qwant](http://www.qwant.com)
-* [Zapmeta](http://www.zapmeta.com)
 * [Swisscows](https://swisscows.com/)
 
 ## [↑](#-Table-of-Contents) Specialty Search Engines
@@ -193,6 +192,7 @@ algorithms, knowledgebase and AI technology.
 
 * [Carrot2](http://search.carrot2.org) - Organizes your search results into topics.
 * [Yippy](http://yippy.com) - Search using multiple sources at once
+* [Zapmeta](http://www.zapmeta.com)
 
 ## [↑](#-Table-of-Contents) Similar Sites Search
 


### PR DESCRIPTION
Transferred [ZapMeta](https://www.zapmeta.com) to this section, because it searches using multiple engines
Please, pay attention to Yippy, idk what to do with it. Seems like they are still working, but couldn't find an actual search. The link just redirects to DuckDuckGo - yippy.com.