### PR TITLE
Removes Alexa.com (service shut down)

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,6 @@ algorithms, knowledgebase and AI technology.
 
 * [Accuranker](https://www.accuranker.com)
 * [ahrefs](https://ahrefs.com) - A tool for backlink research, organic traffic research, keyword research, content marketing & more.
-* [Alexa](http://www.alexa.com)
 * [Azure Tenant Resolution by PingCastle](https://tenantresolution.pingcastle.com) - Search for Azure Tenant using its domain name or its ID 
 * [Bing Webmaster Tools](http://www.bing.com/toolbox/webmaster)
 * [BuiltWith](http://builtwith.com) - is a website that will help you find out all the technologies used to build a particular websites.


### PR DESCRIPTION
This is just a quick one to remove the Alexa entry from Domain and IP Research [<sup>1</sub>](https://github.com/jivoi/awesome-osint#-domain-and-ip-research) section, as Alexa.com has been retired as of May 2022 [<sup>2</sup>](https://web.archive.org/web/20221126132843/https://support.alexa.com/hc/en-us/articles/4410503838999), and is longer accessible.

Source: https://web.archive.org/web/20221126132843/https://support.alexa.com/hc/en-us/articles/4410503838999

Thanks for all the work you've done compiling and maintaining this list, it's a super useful resource :)