### PR TITLE
Adds Web-Check under Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ algorithms, knowledgebase and AI technology.
 * [Threat Jammer](https://threatjammer.com) - Risk scoring service from curated threat intelligence data.
 * [urlQuery](http://urlquery.net)
 * [URLVoid](http://www.urlvoid.com) - Analyzes a website through multiple blacklist engines and online reputation tools to facilitate the detection of fraudulent and malicious websites.
-* [Web-Check](https://web-check.as93.net/) - All-in-one tool for viewing website and server meta data
+* [Web-Check](https://web-check.as93.net/) - All-in-one tool for viewing website and server meta data.
 * [WebMeUp](http://webmeup.com) - is the Web's freshest and fastest growing backlink index, and the primary source of backlink data for SEO PowerSuite.
 * [Website Informer](http://website.informer.com)
 * [WebsiteTechMiner.py](https://github.com/cybersader/WebsiteTechMiner-py) - automates gathering website profiling data into a CSV from the "BuiltWith" or "Wappalyzer" API for tech stack information, technographic data, website reports, website tech lookups, website architecture lookups, etc.

--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ algorithms, knowledgebase and AI technology.
 * [Threat Jammer](https://threatjammer.com) - Risk scoring service from curated threat intelligence data.
 * [urlQuery](http://urlquery.net)
 * [URLVoid](http://www.urlvoid.com) - Analyzes a website through multiple blacklist engines and online reputation tools to facilitate the detection of fraudulent and malicious websites.
+* [Web-Check](https://web-check.as93.net/) - All-in-one tool for viewing website and server meta data
 * [WebMeUp](http://webmeup.com) - is the Web's freshest and fastest growing backlink index, and the primary source of backlink data for SEO PowerSuite.
 * [Website Informer](http://website.informer.com)
 * [WebsiteTechMiner.py](https://github.com/cybersader/WebsiteTechMiner-py) - automates gathering website profiling data into a CSV from the "BuiltWith" or "Wappalyzer" API for tech stack information, technographic data, website reports, website tech lookups, website architecture lookups, etc.


### PR DESCRIPTION
Adds _Web-Check_ under the _Domain & IP Research_ section.

Source: https://github.com/lissy93/web-check

This is just a tool for fetching, analyzing and displaying various pieces of meta from a given URL. Like SSL chain, cookies, headers, DNS records, ports, redirects, analytics, server arch...

> **Note**
Association / disclaimer: I'm the maintainer. But it's open source, has no revenue model, and I believe relevant. Just thought it was best to mention that in the interest of transparency :)