### PR TITLE
Removed broken Twitter tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,44 +318,24 @@ algorithms, knowledgebase and AI technology.
 
 ### [↑](#-Table-of-Contents) Twitter
 
-* [Alldaytrends](https://alldaytrends.com) - A website where you can find trending hashtags.
-* [Backtweets](http://backtweets.com) - BackTweets is a Twitter analytics tool that allows users to search through a Tweet archive.
-* [Blue Nod](http://bluenod.com)
 * [ExportData](https://www.exportdata.io/) - Data export tool for historical tweets, followers & followings and historical trends.
 * [Foller.me](http://foller.me)
-* [Followerwonk](http://followerwonk.com)
-* [GeoSocial Footprint](http://geosocialfootprint.com)
-* [GetTwitterID](http://gettwitterid.com)
-* [Ground Signal](https://www.groundsignal.com)
 * [HappyGrumpy](https://www.happygrumpy.com)
-* [Harvard TweetMap](http://worldmap.harvard.edu/tweetmap)
-* [Hashtagify](http://hashtagify.me)
-* [Hashtags.org](http://www.hashtags.org)
 * [MyTweetAlerts](https://www.mytweetalerts.com/) - A tool to create custom email alerts based on Twitter search.
 * [OneMillionTweetMap](http://onemilliontweetmap.com)
 * [RiteTag](https://ritetag.com)
 * [Sentiment140](http://www.twittersentiment.appspot.com)
-* [Social Bearing](http://www.socialbearing.com)
-* [Spoonbill](http://spoonbill.io)
 * [Tagdef](https://tagdef.com)
-* [Tinfoleak](https://tinfoleak.com)
 * [Trends Predictions](https://trendspredictions.com/) - A tool for discovering new trending topics.
 * [Trends24](http://trends24.in)
-* [TrendsMap](http://trendsmap.com)
-* [Todaytagz](https://todaytagz.com)
 * [TwChat](http://twchat.com)
-* [TweetArchivist](http://www.tweetarchivist.com)
 * [TweetDeck](https://www.tweetdeck.com)
 * [TweetMap](http://mapd.csail.mit.edu/tweetmap)
 * [TweetMap](http://worldmap.harvard.edu/tweetmap)
-* [TweetStats](http://www.tweetstats.com)
-* [Twiangulate](http://www.twiangulate.com)
-* [Twitonomy](http://www.twitonomy.com)
 * [Twitter Advanced Search](https://twitter.com/search-advanced?lang=en)
 * [Twitter Audit](https://www.twitteraudit.com)
 * [Twitter Chat Schedule](http://tweetreports.com/twitter-chat-schedule)
 * [Twitter Search](http://search.twitter.com)
-* [Schedule Warble](https://warble.co)
 
 ### [↑](#-Table-of-Contents) Facebook
 


### PR DESCRIPTION
Heya @jivoi

I've gone through all the tools within the Social Media Tools --> Twitter section, and removed those of which are either no longer functional, or have been down for a significant amount of time.

Since the recent changes to the Twitter API, a lot of apps that relied on Twitter data, have now stopped working.

Changes:
- Removed `alldaytrends`, as no longer accessible
- Removed `backtweets`, as no longer functional
- Removed `bluenod`, as domain has been sold / parked
- Removed `followerwonk`, as aquired by Fedica
- Removed `geosocialfootprint`, as no longer functional
- Removed `gettwitterid`, as domain purchased to marketing company
- Removed `groundsignal`, as not an OSINT tool (beverage marketing)
- Removed `Harvard TweetMap`, as no longer accessible (redirect to other Harvard maps)
- Removed `hashtagify`, as Twitter data no longer loads
- Removed `Hashtags.org`, as Twitter data no longer loads
- Removed `Social Bearing` as Twitter data no longer loads
- Removed `spoonbill` as Twitter data no longer loads
- Removed `tinfoleak` as Twitter data no longer loads
- Removed `trendsmap` as Twitter data no longer loads
- Removed `todaytagz` as domain has been transfered
- Removed `tweetarchivist` as Twitter data no longer loads
- Removed `tweetstats` as Twitter data no longer loads
- Removed `twiangulate` as Twitter data no longer loads
- Removed `twitonomy` as project is dead
- Removed `warble` as Twitter data no longer loads

Most of what remains is either still functional, or was behind a paywall, and as such I wasn't able to test.

Feels quite sad to be submitting a PR that removes so many previously valuable tools 😢 (my [Twitter OSINT app](https://github.com/Lissy93/twitter-sentiment-visualisation) also had to be retired). But having the broken apps still on this list, would make it harder for readers to find the still functional services, so I think it's for the best.