### PR TITLE
Add PryingDeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,6 +1319,7 @@ urls and other data effortlessly
 * [OSINT.SH](https://osint.sh/) - Information Gathering Toolset.
 * [FOCA](https://github.com/ElevenPaths/FOCA) - Tool to find metadata and hidden information in the documents.
 * [Sub3 Suite](https://github.com/3nock/sub3suite) - A research-grade suite of tools for intelligence gathering & target mapping with both active and passive(100+ modules) intelligence gathering capabilities.
+* [PryingDeep](https://github.com/iudicium/pryingdeep) -  An OSINT instrument for the Deep Web.
 
 
 ## [↑](#-table-of-contents) Threat Intelligence


### PR DESCRIPTION
Pryingdeep is a dark web OSINT tool specializing  in extracting information through customizable modules.
It's primary goal to maximize information extraction from dark web sources.