### PR TITLE
Add Google Maps Scraper (Unofficial Google Places API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Geospatial Research and Mapping Tools
 
+* [Apify's Google Maps Scraper](https://apify.com/compass/crawler-google-places)
 * [ArcGIS](https://livingatlas.arcgis.com/en/browse/)
 * [Atlasify](http://www.atlasify.com)
 * [Baidu Maps](https://map.baidu.com/)


### PR DESCRIPTION
Disclaimer: self-promotion but there's a forever free plan. Extracts geolocation, reviews, contact details, images; no limit on places. Can scrape areas by URLs, location + search query, polygons. Can scrape large areas economically by focusing on populated areas like cities and skipping deserts, lakes, mountains, etc.

Can be used for independent OSINT work e.g. https://blog.apify.com/google-maps-data-tourism/