### PR TITLE
Added SearXNG to the Meta Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ algorithms, knowledgebase and AI technology.
 * [iZito](http://www.izito.com)
 * [Myallsearch](http://www.myallsearch.com)
 * [Qwant](http://www.qwant.com)
+* [SearXNG](https://github.com/searxng/searxng)
 * [Swisscows](https://swisscows.com/)
 
 ## [↑](#-table-of-contents) Specialty Search Engines


### PR DESCRIPTION
I added SearXNG under Meta Search.

[(Info from docs.searxng.org)](docs.searxng.org)

> SearXNG is a free internet metasearch engine which aggregates results from more than 70 search services. Users are neither tracked nor profiled. Additionally, SearXNG can be used over Tor for online anonymity. SearXNG development has been started in the middle of 2021 as a fork of the searx project.