### PR TITLE
Add EZR OSINT Sidebar to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,6 +1304,7 @@ algorithms, knowledgebase and AI technology.
 * [DNSservices](https://github.com/0x4f53/dnsservices) - Discover embedded services in a domain's DNS records within seconds
 * [DuckDuckGo URL scraper](https://github.com/its0x08/duckduckgo) - A simple DuckDuckGo URL scraper. 
 * [eScraper](https://escraper.emagicone.com/) - Grab product descriptions, prices, image
+* [EZR OSINT Sidebar](https://chromewebstore.google.com/detail/ezr-osint-sidebar/joagbbgciboooipadijeaoidjjigdmof) - A free Chrome extension that allows you to easily conduct and document your online investigations.
 * [FOCA](https://github.com/ElevenPaths/FOCA) - Tool to find metadata and hidden information in the documents.
 * [Glit](https://github.com/shadawck/glit) -  Retrieve all mails of users related to a git repository, a git user or a git organization.
 * [Greynoise](https://greynoise.io/) - "Anti-Threat Intelligence" Greynoise characterizes the background noise of the internet, so the user can focus on what is actually important.  


### PR DESCRIPTION
## Add EZR OSINT Sidebar

This is self-promotion of a free chrome extension I built to assist in documenting online investigations. I have added it to the **Other Tools** section. For more info on it's functionality see [here](https://chromewebstore.google.com/detail/ezr-osint-sidebar/joagbbgciboooipadijeaoidjjigdmof) or [here](https://www.youtube.com/watch?v=PtsfD_HhvfE).

Thank you so much for maintaining this list! It is **so** helpful. 