### PR TITLE
adding new Geospatial Research and Mapping Tool Atlas.co.

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,7 @@ algorithms, knowledgebase and AI technology.
 
 * [Apify's Google Maps Scraper](https://apify.com/compass/crawler-google-places)
 * [ArcGIS](https://livingatlas.arcgis.com/en/browse/)
+* [Atlas](https://atlas.co)
 * [Atlasify](http://www.atlasify.com)
 * [Baidu Maps](https://map.baidu.com/)
 * [Batchgeo](http://batchgeo.com)


### PR DESCRIPTION
Atlas.co is a cloud-based GIS and mapping tool: https://atlas.co/. You can read more here: https://techcrunch.com/2024/11/14/atlas-co-wants-its-web-based-mapping-tool-to-be-the-figma-of-geospatial-data/

Self-promotional