### PR TITLE
Add Cyberbro and CyberGordon - CTI tools for checking observable reputation using multiple engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,6 +1324,8 @@ algorithms, knowledgebase and AI technology.
 * [Barcode Reader](http://online-barcode-reader.inliteresearch.com) - Decode barcodes in C#, VB, Java, C\C++, Delphi, PHP and other languages.
 * [Belati](https://github.com/aancw/Belati) - Belati - The Traditional Swiss Army Knife For OSINT. Belati is tool for Collecting Public Data & Public Document from Website and other service for OSINT purpose.
 * [BeVigil-CLI](https://github.com/Bevigil/BeVigil-OSINT-CLI) - A unified command line interface and python library for using BeVigil OSINT API to search for assets such as subdomains, URLs, applications indexed from mobile applications.
+* [Cyberbro](https://github.com/stanfrbd/cyberbro) - A self-hosted application, available as a Dockerized, for effortless searching and reputation checking of observables. Extracts IoCs from raw input and check their reputation using multiple services.
+* [CyberGordon](https://cybergordon.com) - CyberGordon is a threat intelligence search engine. It leverages 30+ sources.
 * [CantHide](https://canthide.me) - CantHide finds previous locations by looking at a given social media account.
 * [CrowdSec](https://github.com/crowdsecurity/crowdsec) - An open source, free, and collaborative IPS/IDS software written in Go, able to analyze visitor behavior & provide an adapted response to all kinds of attacks.
 * [Datasploit](https://github.com/DataSploit/datasploit) - Tool to perform various OSINT techniques on usernames, emails addresses, and domains.


### PR DESCRIPTION
Hello,

I added two tools that are publicly available and of public interest.

* Added Cyberbro in "other tools" section, it is a tool I am developing and that is available on Github. It is a Python app that can be self-hosted. Link: https://github.com/stanfrbd/cyberbro

![image](https://github.com/user-attachments/assets/f8078266-09c1-4c5d-b23a-484527b63ec7)

* Added CyberGordon in "other tools" section, it is a CTI search engine for searching observables. Link: https://cybergordon.com

![image](https://github.com/user-attachments/assets/83e2e383-f748-4f59-ae8c-daa2cfc5d385)

