### PR TITLE
added TgramSearch and Teleteg.

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,9 @@ algorithms, knowledgebase and AI technology.
 
 ### [↑](#-table-of-contents) Telegram
 
-* [Maltego Telegram](https://github.com/vognik/maltego-telegram) - Rich Set of Entities & Transforms for OSINT on Telegram with Maltego
+* [Maltego Telegram](https://github.com/vognik/maltego-telegram) - Rich Set of Entities & Transforms for OSINT on Telegram with Maltego.
+* [TgramSearch](https://tgramsearch.com/) - Convenient search for Telegram channels, as well as a structured catalog with over 700000 Telegram channels. Available in 8+ Languages.
+* [Teleteg](https://teleteg.com/) - The ultimate Telegram search engine. 10 results for free plan.  
 * [Telegago](https://cse.google.com/cse?q=+&cx=006368593537057042503:efxu7xprihg#gsc.tab=0&gsc.q=%20&gsc.page=1) - A Google Advanced Search specifically for finding public and private Telegram Channels and Chatrooms. 
 * [Telegram Nearby Map](https://github.com/tejado/telegram-nearby-map) - Webapp based on OpenStreetMap and the official Telegram library to find the position of nearby users.
 


### PR DESCRIPTION
Used for Finding More than 70000+ Telegram Channels both Public and Private. Categorize search of telegram channels by groups, channels, messages, etc.