### PR TITLE
Update search engines: remove Parsijoo, Najdsi; add Gerdoo, Zarebin

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,20 +123,20 @@ algorithms, knowledgebase and AI technology.
 * [Baidu (China)](http://www.baidu.com) - The major search engine used in China
 * [Daum (South Korea)](https://www.daum.net/)
 * [Eniro (Sweden)](http://www.eniro.se)
+* [Gerdoo (Iran)](http://gerdoo.me)
 * [Goo (Japan)](http://www.goo.ne.jp)
-* [Najdsi (Slovenia)](http://www.najdi.si)
+* [Najdi (Slovenia)](http://www.najdi.si)
 * [Naver (South Korea)](http://www.naver.com)
 * [Onet.pl (Poland)](http://www.onet.pl)
 * [Orange (France)](http://www.orange.fr)
 * [Parseek (Iran)](http://www.parseek.com)
-* [Parsijoo (Iran)](https://www.parsijoo.ir/)
 * [SAPO (Portugal)](http://www.sapo.pt)
 * [Search.ch (Switzerland)](http://www.search.ch)
 * [Seznam(Czech Republic)](https://seznam.cz)
 * [SoGou (China)](http://www.sogou.com/)
 * [Walla (Israel)](http://www.walla.co.il)
 * [Yandex (Russia)](http://www.yandex.com)
-* [Najdi.si (Slovenia)](http://www.najdi.si/)
+* [Zarebin (Iran)](http://zarebin.ir)
 
 ## [↑](#-table-of-contents) Meta Search
 


### PR DESCRIPTION
Fixes #696. Removed defunct Parsijoo and duplicate Najdsi entries from Main National Search Engines in README.md. Added Gerdoo and Zarebin as active Iranian search engines. Re-alphabetized the list per contribution guidelines.