### PR TITLE
Deleted Google similiar sites chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ algorithms, knowledgebase and AI technology.
 
 *Find websites that are similar. Good for business competition research.*
 
-* [Google Similar Pages](https://chrome.google.com/webstore/detail/google-similar-pages/pjnfggphgdjblhfjaphkjhfpiiekbbej)
 * [SimilarSites](http://www.similarsites.com) - Discover websites that are similar to each other
 * [SitesLike](http://www.siteslike.com) - Find similar websites by category
 


### PR DESCRIPTION
Said extension doesn't seem to be available on the Chrome web store anymore.

[https://chrome.google.com/webstore/detail/google-similar-pages/pjnfggphgdjblhfjaphkjhfpiiekbbej](https://chrome.google.com/webstore/detail/google-similar-pages/pjnfggphgdjblhfjaphkjhfpiiekbbej)

<img width="683" height="628" alt="image" src="https://github.com/user-attachments/assets/d1474070-95a4-49d5-afc7-18120fd77641" />
