### PR TITLE
Remove archived repositories: Pown Recon, Sterraxcyl, Belati, Geogramint

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,6 @@ algorithms, knowledgebase and AI technology.
 * [InstagramPrivSniffer](https://github.com/obitouka/InstagramPrivSniffer) - Views Instagram PRIVATE ACCOUNT'S media without login 😱.
 * [Osintgram](https://github.com/Datalux/Osintgram) - Osintgram offers an interactive shell to perform analysis on Instagram account of any users by its nickname.
 * [Osintgraph](https://github.com/XD-MHLOO/Osintgraph) - Tool that maps your target’s Instagram data and relationships in Neo4j for social network analysis. 
-* [Sterra](https://github.com/novitae/sterraxcyl) - Instagram OSINT tool to export and analyse followers | following with their details
 * [Toutatis](https://github.com/megadose/toutatis) - a tool that allows you to extract information from instagrams accounts such as s, phone numbers and more
 
 ### [↑](#-table-of-contents) Pinterest
@@ -537,7 +536,6 @@ algorithms, knowledgebase and AI technology.
 ### [↑](#-table-of-contents) Telegram
 
 * [CCTV](https://github.com/IvanGlinkin/CCTV) - Close-Circuit Telegram Vision revolutionizes location tracking with its open-source design and Telegram API integration. Offering precise tracking within 50-100 meters, users can monitor others in real-time for logistics or safety, redefining how we navigate our surroundings.
-* [Geogramint](https://github.com/Alb-310/Geogramint) - An OSINT Geolocalization tool for Telegram that find nearby users and groups.
 * [GroupDa](https://groupda.com/telegram/group/search) - Can be used for Searching Telegram Channels. Search by Category, Countries and Language.
 * [Maltego Telegram](https://github.com/vognik/maltego-telegram) - Rich Set of Entities & Transforms for OSINT on Telegram with Maltego.
 * [Telegram Finder](https://www.telegram-finder.io/) - A tool to find Telegram users by their phone number, linkedin url or email.
@@ -1507,7 +1505,6 @@ algorithms, knowledgebase and AI technology.
 
 * [aadinternals](https://aadinternals.com/osint) - Provides tools and insights for advanced analysis and security testing of Azure Active Directory (AAD) and Microsoft 365.
 * [Barcode Reader](http://online-barcode-reader.inliteresearch.com) - Decode barcodes in C#, VB, Java, C\C++, Delphi, PHP and other languages.
-* [Belati](https://github.com/aancw/Belati) - The Traditional Swiss Army Knife For OSINT. Belati is tool for Collecting Public Data & Public Document from Website and other service for OSINT purpose.
 * [BeVigil-CLI](https://github.com/Bevigil/BeVigil-OSINT-CLI) - A unified command line interface and python library for using BeVigil OSINT API to search for assets such as subdomains, URLs, applications indexed from mobile applications.
 * [Cyberbro](https://github.com/stanfrbd/cyberbro) - A self-hosted application, available as a Dockerized, for effortless searching and reputation checking of observables. Extracts IoCs from raw input and check their reputation using multiple services.
 * [CyberGordon](https://cybergordon.com) - CyberGordon is a threat intelligence search engine. It leverages 30+ sources.
@@ -1533,7 +1530,6 @@ algorithms, knowledgebase and AI technology.
 * [OsintStalker](https://github.com/milo2012/osintstalker) - Python script for Facebook and geolocation OSINT.
 * [Outwit](http://www.outwit.com) - Find, grab and organize all kinds of data and media from online sources.
 * [Photon](https://github.com/s0md3v/Photon) - Crawler designed for OSINT
-* [Pown Recon](https://github.com/pownjs/pown-recon) - Target reconnaissance framework powered by graph theory.
 * [pygreynoise](https://github.com/GreyNoise-Intelligence/pygreynoise) - Greynoise Python Library
 * [QuickCode](https://quickcode.io/) - Python and R data analysis environment.
 * [Router Passwords](https://www.routerpasswords.com) - Online database of default router passwords.


### PR DESCRIPTION
This PR removes five archived, read-only repositories from the awesome-osint list, as proposed in [Issue #713](https://github.com/jivoi/awesome-osint/issues/713). These repositories are no longer maintained by their owners, which could mislead users relying on the list for functional OSINT tools. Removing them aligns with the [awesome manifesto](https://github.com/sindresorhus/awesome/blob/master/awesome.md) by prioritizing high-quality, active resources.
Changes Made

```text
Removed [Pown Recon](https://github.com/pownjs/recon) - ... entry
Removed [Sterraxcyl](https://github.com/novitae/sterraxcyl) - ... entry
Removed [Belati](https://github.com/aancw/Belati) - ... entry
Removed [Geogramint](https://github.com/Alb-310/Geogramint) - ... entry
```

Entries were removed alphabetically within their respective sections to maintain the list's organization.
Verification

All repositories remain archived and read-only as of September 24, 2025:
- [Pown Recon](https://github.com/pownjs/recon) (Archived: Oct 22, 2022)
- [Sterraxcyl](https://github.com/novitae/sterraxcyl) (Archived: Oct 7, 2024)
- [Belati](https://github.com/aancw/Belati) (Archived: Apr 4, 2024)
- [Geogramint](https://github.com/Alb-310/Geogramint) (Archived: Sep 7, 2024)


No trailing whitespace added; spelling and grammar checked.
This is not self-promotional—I have no affiliation with these projects.

Closes #713.
Thank you for maintaining this valuable resource for the OSINT community!