### PR TITLE
Add Shotstars

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ algorithms, knowledgebase and AI technology.
 
 * [github_monitor](https://github.com/misiektoja/github_monitor) - Tool for real-time tracking of GitHub users' activities including profile and repository changes with support for email alerts, CSV logging, detection when a user blocks or unblocks you and more
 * [GithubRecon](https://kriztalz.sh/github-recon/) - Lookup Github users by username or email and gather associated data.
+* [Shotstars](https://github.com/snooppr/shotstars) - An advanced tool for checking GitHub repositories, with star statistics, including fake star analysis and data visualization.
 
 ## [↑](#-table-of-contents) Blog Search
 


### PR DESCRIPTION
Add Shotstars - An advanced tool for checking GitHub repositories, with star statistics, including fake star analysis and data visualization. 