### PR TITLE
Add PageStash to Web History and Website Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,6 +950,8 @@ algorithms, knowledgebase and AI technology.
 * [Wayback Machine](http://archive.org/web/web.php) - Explore the history of a website.
 * [Wayback Machine Archiver](https://github.com/jsvine/waybackpack)
 * [waybackpy](https://github.com/akamhy/waybackpy) - Python package & CLI tool that interfaces the Wayback Machine APIs.
+* [PageStash](https://pagestash.app/) — Capture full web pages (screenshots + HTML + text) and organize them with notes, tags, and visual graphs.
+
 
 ## [↑](#-table-of-contents) Language Tools
 


### PR DESCRIPTION
Added PageStash (https://pagestash.app/) to the Web History and Website Capture section. 
PageStash helps analysts capture full pages (HTML+screenshots+text) and preserve evidence for OSINT & investigation workflows.
