### PR TITLE
Add user-scanner to README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ algorithms, knowledgebase and AI technology.
 * [TuriBot](https://t.me/TuriBot) — Resolves username from Telegram ID.
 * [Unamer](https://telegram.me/unamer_bot) — Username ownership history.
 * [username_to_id_bot](https://t.me/username_to_id_bot) — Returns user/chat/channel/bot ID.
+* [user-scanner](https://github.com/kaifcodec/user-scanner.git) — Check a username's presence across dev/social/gaming/creator site
 * [UsInfoBot](https://t.me/usinfobot) — Resolves username from ID (inline).
 * [WhoisDomBot](https://t.me/WhoisDomBot) — Whois lookup for domains/IPs + dig/trace.
 


### PR DESCRIPTION
user-scanner a CLI tool that checks username's presence across all popular sites and games, with robust error handling.