### PR TITLE
Add ArkhamMirror to Other Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1575,6 +1575,7 @@ algorithms, knowledgebase and AI technology.
 ## [↑](#-table-of-contents) Other Tools
 
 * [aadinternals](https://aadinternals.com/osint) - Provides tools and insights for advanced analysis and security testing of Azure Active Directory (AAD) and Microsoft 365.
+* [ArkhamMirror](https://github.com/mantisfury/ArkhamMirror) - Local-first AI document intelligence with offline RAG, contradiction detection, knowledge graphs, and vision AI table extraction.
 * [Barcode Reader](http://online-barcode-reader.inliteresearch.com) - Decode barcodes in C#, VB, Java, C\C++, Delphi, PHP and other languages.
 * [BeVigil-CLI](https://github.com/Bevigil/BeVigil-OSINT-CLI) - A unified command line interface and python library for using BeVigil OSINT API to search for assets such as subdomains, URLs, applications indexed from mobile applications.
 * [Cyberbro](https://github.com/stanfrbd/cyberbro) - A self-hosted application, available as a Dockerized, for effortless searching and reputation checking of observables. Extracts IoCs from raw input and check their reputation using multiple services.


### PR DESCRIPTION
Adding ArkhamMirror, a local-first AI document intelligence tool for investigative journalists and OSINT analysts.

Features offline RAG, contradiction detection across documents, knowledge graph visualization, and vision AI table extraction.

MIT licensed, runs 100% locally with no cloud dependencies.