### PR TITLE
Add isMalicious to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,7 @@ algorithms, knowledgebase and AI technology.
 * [HypeStat](https://www.hypestat.com)
 * [Icann Lookup](https://lookup.icann.org/en/lookup) - The site allows you to look up domain registration information (WHOIS) on the internet
 * [Infosniper](http://www.infosniper.net)
+* [isMalicious](https://ismalicious.com) - Threat intelligence platform aggregating malicious IP and domain data from multiple security feeds with real-time reputation scoring and threat categorization.
 * [intoDNS](http://www.intodns.com)
 * [IP 2 Geolocation](http://ip2geolocation.com)
 * [IP 2 Location](http://www.ip2location.com/demo.aspx)


### PR DESCRIPTION
## Summary

Add [isMalicious](https://ismalicious.com) to the **Domain and IP Research** section.

## About isMalicious

isMalicious is a threat intelligence platform useful for OSINT investigations:

- Check IP and domain reputation against multiple threat feeds
- Real-time scoring (0-100 confidence score)
- Threat categorization (phishing, malware, C2, botnet, ransomware, spam, scam)
- Free API tier and browser extensions for quick lookups

## Use Case for OSINT

During investigations, analysts can quickly check if an IP or domain is associated with malicious activity, similar to how they'd use IPVoid, URLVoid, or VirusTotal.

## Disclosure

I am the creator of isMalicious. Submitting per contribution guidelines that require upfront disclosure of self-promotion.

## Checklist

- [x] Read the awesome manifesto
- [x] Searched for duplicates
- [x] Entry added alphabetically (between Infosniper and intoDNS)
- [x] Follows format: `[Name](link) - description`
- [x] Checked spelling and grammar