### PR TITLE
Add NullSec Linux - Security distro with OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,6 +1561,7 @@ algorithms, knowledgebase and AI technology.
 * [Surveilliance Self Defense](https://ssd.eff.org)
 * [Tails](https://tails.boum.org)
 * [Thunderbird](https://www.thunderbird.net/en-US/)
+* [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security distribution with 135+ OSINT, recon, and security tools
 * [Tor Project](https://www.torproject.org)
 * [uBlock Origin](https://github.com/gorhill/uBlock)
 * [Wickr](https://wickr.com)


### PR DESCRIPTION
## NullSec Linux

A security distribution with 135+ tools including OSINT and reconnaissance capabilities.

### OSINT/Recon Features
- Network reconnaissance tools
- Domain/subdomain enumeration
- Social engineering tools
- Information gathering
- OSINT frameworks

### Technical Details
- Debian 13 (Trixie) base
- 135+ pre-installed tools
- AMD64, ARM64 support

### Links
- GitHub: https://github.com/bad-antics/nullsec-linux
- Release: https://github.com/bad-antics/nullsec-linux/releases/tag/v5.0.0

Fits in the Privacy/Security Tools section alongside Tails.