### PR TITLE
Add NullSec Recon to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,6 +913,7 @@ algorithms, knowledgebase and AI technology.
 * [Infosniper](http://www.infosniper.net)
 * [isMalicious](https://ismalicious.com) - Threat intelligence platform aggregating malicious IP and domain data from multiple security feeds with real-time reputation scoring and threat categorization.
 * [intoDNS](http://www.intodns.com)
+* [NullSec Recon](https://github.com/bad-antics/nullsec-recon) - Automated reconnaissance framework for subdomain enumeration, port scanning, and service fingerprinting.
 * [IP 2 Geolocation](http://ip2geolocation.com)
 * [IP 2 Location](http://www.ip2location.com/demo.aspx)
 * [IP Geolocation API DB-IP](https://db-ip.com) - Pprovides IP geolocation and intelligence.


### PR DESCRIPTION
## Description
Adding NullSec Recon to the Domain and IP Research section.

**NullSec Recon** is an automated reconnaissance framework featuring:
- Subdomain enumeration
- Port scanning and service detection
- Service fingerprinting
- Technology stack detection
- Output in multiple formats (JSON, CSV, HTML)

Repository: https://github.com/bad-antics/nullsec-recon