### PR TITLE
Add NullSec Linux to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1604,6 +1604,7 @@ algorithms, knowledgebase and AI technology.
 * [OpenRefine](https://github.com/OpenRefine) - Free & open source power tool for working with messy data and improving it.
 * [Orbit](https://github.com/s0md3v/Orbit) - Draws relationships between crypto wallets with recursive crawling of transaction history.
 * [OSINT Framework](http://osintframework.com/) - Web based framework for OSINT.
+* [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security-focused Linux distribution with 135+ tools including network reconnaissance, traffic analysis, and information gathering utilities.
 * [OSINT-Tool](https://www.osint-tool.com/) - A browser extension that gives you access to a suite of OSINT utilities (Dehashed, Epieos, Domaintools, Exif data, Reverse image search, etc) directly on any webpage you visit.
 * [OSINT.SH](https://osint.sh/) - Information Gathering Toolset.
 * [OsintStalker](https://github.com/milo2012/osintstalker) - Python script for Facebook and geolocation OSINT.


### PR DESCRIPTION
## Description

Adds [NullSec Linux](https://github.com/bad-antics/nullsec-linux) to the Other Tools section.

## About NullSec Linux

Security-focused GNU/Linux distribution with **135+ tools** including OSINT-relevant utilities:

- **nullsec-netseer** - Network reconnaissance and traffic analysis
- **nullsec-awsrecon** - AWS enumeration
- **nullsec-gcphunt** - GCP security hunting  
- **nullsec-cloudaudit** - Multi-cloud security auditing

Plus cloud, AI/ML, hardware, and mobile security tools.

**Architectures:** AMD64, ARM64, RISC-V, Apple Silicon

## Checklist

- [x] Follows existing format
- [x] Placed alphabetically (after OSINT Framework)
- [x] Description focuses on OSINT relevance