### PR TITLE
Add Steam-OSINT tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,8 @@ algorithms, knowledgebase and AI technology.
 
 * [OSINT-Steam](https://osint-steam.vercel.app/en) - An [open-source](https://github.com/Berchez/OSINT-steam) tool that returns public information, such as friends list and possible locations, from Steam profiles.
 
+* [Steam-OSINT](https://github.com/matiash26/steam-osint) - Open-source OSINT tool for accurate mutual friends analysis on Steam, supporting full friend lists.
+
 ### [↑](#-table-of-contents) GitHub
 
 * [github_monitor](https://github.com/misiektoja/github_monitor) - Tool for real-time tracking of GitHub users' activities including profile and repository changes with support for email alerts, CSV logging, detection when a user blocks or unblocks you and more


### PR DESCRIPTION
Added Steam-OSINT, an open-source OSINT tool for accurate Steam mutual friends analysis.
The tool retrieves the full friends list, avoiding common 100-friends limitations.