### PR TITLE
Add Marshall Browser to Browsers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,6 +1394,7 @@ algorithms, knowledgebase and AI technology.
 * [Comodo Dragon](https://www.comodo.com/home/browsers-toolbars/browser.php)
 * [Coowon](http://coowon.com)
 * [Gnu Icecat](https://icecatbrowser.org/) - 
+* [Marshall Browser](https://github.com/bad-antics/marshall) - GTK4/WebKit2GTK privacy browser with built-in OSINT tools, Dr. Marshall AI assistant, and comprehensive ad/tracker blocking.
 * [Edge](https://www.microsoft.com/en-us/windows/microsoft-edge/microsoft-edge)
 * [Firefox](https://www.mozilla.org)
 * [Maxthon](http://www.maxthon.com)


### PR DESCRIPTION
## Description
Adds [Marshall Browser](https://github.com/bad-antics/marshall) to the Browsers section.

## About Marshall Browser
A GTK4/WebKit2GTK privacy-focused browser with OSINT capabilities:
- **Built-in OSINT Tools**: Privacy-enhanced search with intelligence gathering
- **Dr. Marshall AI**: Grok-level AI assistant with 10+ LLM providers
- **Privacy Features**: Comprehensive ad/tracker blocking, no telemetry
- **Workforce Center**: Employee management, timecards, projects
- **VoIP Suite**: SIP/WebRTC calling built-in

Perfect for OSINT researchers needing a privacy-respecting browser with integrated tools.

## Checklist
- [x] Searched for duplicates
- [x] Entry follows `[Name](link) - Description` format
- [x] Alphabetical order maintained (placed after Gnu Icecat)