### PR TITLE
Update link: geoguessr.ai -> reverseimagelocation.com (Official Rebra…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ algorithms, knowledgebase and AI technology.
 * [Flash Earth](http://www.flashearth.com)
 * [GeoGig](http://geogig.org)
 * [GeoInfer](https://geoinfer.com) - Image geolocation tool, no EXIF data required.
-* [GeoGuessr.ai](https://geoguessr.ai) - AI-powered geolocation tool for identifying locations from images.
+* [ReverseImageLocation](https://reverseimagelocation.com) - AI-powered geolocation tool for identifying locations from images.
 * [GeoNames](http://www.geonames.org)
 * [Google Earth Pro](https://www.google.com/intl/en/earth/versions/#earth-pro)
 * [Google Earth](http://www.google.com/earth)


### PR DESCRIPTION
…nding)

The tool previously listed as 'geoguessr.ai' has officially rebranded to 'Reverse Image Location' to resolve trademark conflicts. 

The old domain is being deprecated. This update points to the new official domain to ensure the link remains active and useful for the community. I am the owner of this tool.