### PR TITLE
Add n01d-forge and n01d-machine to Privacy and Encryption Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1539,6 +1539,8 @@ algorithms, knowledgebase and AI technology.
 * [Mailvelope](https://www.mailvelope.com)
 * [Master Password](http://masterpasswordapp.com)
 * [Nixory](http://nixory.sourceforge.net)
+* [n01d-forge](https://github.com/bad-antics/n01d-forge) - Native GUI image burner with LUKS/VeraCrypt encryption support for creating secure bootable drives.
+* [n01d-machine](https://github.com/bad-antics/n01d-machine) - Secure VM manager with Tor/VPN integration and network compartmentalization for anonymous operations.
 * [NoScript](https://noscript.net)
 * [Open DNS](https://www.opendns.com/home-internet-security)
 * [Open PGP](https://www.enigmail.net/index.php/en)


### PR DESCRIPTION
## Description
Adds two Rust-based security tools to the Privacy and Encryption Tools section.

## Additions

### n01d-forge
- **Description**: Native GUI image burner with LUKS/VeraCrypt encryption support for creating secure bootable drives
- **GitHub**: https://github.com/bad-antics/n01d-forge
- **Use case**: Creating encrypted bootable media for OSINT operations

### n01d-machine
- **Description**: Secure VM manager with Tor/VPN integration and network compartmentalization for anonymous operations
- **GitHub**: https://github.com/bad-antics/n01d-machine
- **Use case**: Anonymous VM management for OSINT research

## Why Include?
- Both tools enhance operational security for OSINT practitioners
- Open source Rust implementations
- Native GUI using egui framework
- Complement existing tools like Qubes OS in the list