### PR TITLE
Update URL: GeoGuessr.ai -> ReverseImageLocation.com (Rebranding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ algorithms, knowledgebase and AI technology.
 * [Flash Earth](http://www.flashearth.com)
 * [GeoGig](http://geogig.org)
 * [GeoInfer](https://geoinfer.com) - Image geolocation tool, no EXIF data required.
-* [GeoGuessr.ai](https://geoguessr.ai) - AI-powered geolocation tool for identifying locations from images.
+* [ReverseImageLocation.com](https://reverseimagelocation.com) - AI-powered geolocation tool for identifying locations from images.
 * [GeoNames](http://www.geonames.org)
 * [Google Earth Pro](https://www.google.com/intl/en/earth/versions/#earth-pro)
 * [Google Earth](http://www.google.com/earth)


### PR DESCRIPTION
Hi @jivoi ,

I am the creator of the tool previously listed as **GeoGuessr.ai**.

We have recently rebranded to **ReverseImageLocation.com** to avoid potential trademark conflicts with the official GeoGuessr game. The tool remains the same (AI-powered geolocation for OSINT/Geoguessing), but the domain has changed.

Could you please update the link to reflect this change?

**Change:**
- Old: `https://geoguessr.ai`
- New: `https://reverseimagelocation.com`

Thank you for maintaining this awesome list!