### PR TITLE
Add Epstein Exposed - public interest case file database

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ algorithms, knowledgebase and AI technology.
 *Search for data located on PDFs, Word documents, presentation slides, and more.*
 
 * [DocumentCloud](https://www.documentcloud.org) - Platform for analyzing, annotating, and publishing documents.
+* [Epstein Exposed](https://epsteinexposed.com) - Comprehensive searchable database of 2M+ DOJ Epstein case documents, 1,700+ persons, flight logs, emails, and network graph visualization.
 * [Find-pdf-doc](http://www.findpdfdoc.com)
 * [Free Full PDF](http://www.freefullpdf.com)
 * [Offshore Leak Database](https://offshoreleaks.icij.org)


### PR DESCRIPTION
Adds [Epstein Exposed](https://epsteinexposed.com) to the **Document and Slides Search** section.

Epstein Exposed is a comprehensive, searchable public interest database of the Jeffrey Epstein case files released by the DOJ under H.R.4405. Features include:

- **2,145,445+** searchable DOJ documents with OCR text
- **1,723** person profiles with auto-linked document references
- Flight log browser (1,708 flights)
- Interactive network graph visualization (D3.js)
- Document integrity verification (SHA-256 hash checking)
- Full-text search across all documents and emails
- Public REST API with 27 endpoints

Built with Next.js, fully open to researchers, journalists, and the public. No login required.