### PR TITLE
Add Website-Diff to Web Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1398,6 +1398,7 @@ algorithms, knowledgebase and AI technology.
 * [versionista](http://versionista.com)
 * [visualping](https://visualping.io)
 * [WebReader](http://www.getwebreader.com)
+* [Website-Diff](https://github.com/GeiserX/Website-Diff) - Intelligent web page comparison tool with Wayback Machine artifact cleaning, significance scoring, and multi-browser visual regression testing.
 * [WebSite Watcher](http://www.aignes.com/index.htm)
 * [Winds](http://winds.getstream.io)
 


### PR DESCRIPTION
## Summary

- Adds [Website-Diff](https://github.com/GeiserX/Website-Diff) to the **Web Monitoring** section
- Intelligent web page comparison tool with Wayback Machine artifact cleaning, significance scoring, and multi-browser visual regression testing
- Inserted alphabetically in the existing list

🤖 Generated with [Claude Code](https://claude.com/claude-code)