### PR TITLE
Add Wayback-Archive to Web History and Website Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,6 +1017,7 @@ algorithms, knowledgebase and AI technology.
 * [stored.website](https://stored.website)
 * [Wayback Machine](http://archive.org/web/web.php) - Explore the history of a website.
 * [Wayback Machine Archiver](https://github.com/jsvine/waybackpack)
+* [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
 * [waybackpy](https://github.com/akamhy/waybackpy) - Python package & CLI tool that interfaces the Wayback Machine APIs.
 
 ## [↑](#-table-of-contents) Language Tools


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the **Web History and Website Capture** section, in alphabetical order between Wayback Machine Archiver and waybackpy.
- Wayback-Archive is a Python (GPL-3.0) tool that downloads complete websites from the Wayback Machine with full asset preservation for offline viewing.

## Disclosure

I am the author of Wayback-Archive. Per the contribution guidelines, I am disclosing this up front.