### PR TITLE
Add Lullar — free username/email search (149+ platforms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ algorithms, knowledgebase and AI technology.
 * [Cupidcr4wl](https://github.com/OSINTI4L/cupidcr4wl) - Username and phone number search tool that crawls adult content platforms to see if a targeted account or person is present.
 * [Digital Footprint Check](https://www.digitalfootprintcheck.com/free-checker.html)  - Check for registered username on 100s of sites for free.
 * [IDCrawl](https://www.idcrawl.com/username) - Search for a username in popular social networks.
+* [Lullar](https://com.lullar.com) - Free username and email search across 149+ platforms including social media, forums, gaming, and developer sites.
 * [Maigret](https://github.com/soxoj/maigret) - Collect a dossier on a person by username.
 * [Name Chk](http://www.namechk.com) - Check over 30 domains and more than 90 social media account platforms.
 * [Name Checkr](http://www.namecheckr.com) - checks a domain and username across many platforms.


### PR DESCRIPTION
## Summary

- Adds [Lullar](https://com.lullar.com) to the **Username Check** section (alphabetically between IDCrawl and Maigret).
- Lullar is a free web tool that searches usernames and email addresses across 149+ platforms — social media, forums, gaming, and developer sites — with no signup or account required.

## Disclosure

This is a self-promotional submission. I am the maintainer of Lullar. Submitted in accordance with the project's contributing guidelines.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>