### PR TITLE
Add Hormuz Tracker to Maritime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1607,6 +1607,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Maritime
 
+* [Hormuz Tracker](https://github.com/johnsmalls22-rgb/hormuz-tracker) - Real-time Strait of Hormuz vessel tracking with AIS data, dark ship detection, oil prices, and carrier positions.
 * [VesselFinder](https://www.vesselfinder.com) - a FREE AIS vessel tracking web site. VesselFinder displays real time ship positions and marine traffic detected by global AIS network.
 
 ## [↑](#-table-of-contents) Other Tools


### PR DESCRIPTION
Added [Hormuz Tracker](https://github.com/johnsmalls22-rgb/hormuz-tracker) to the Maritime section.

Real-time Strait of Hormuz vessel tracking dashboard with:
- AIS vessel monitoring (88+ vessels)
- Dark ship detection (disabled transponders)
- Oil price tracking (Brent/WTI)
- US Navy carrier positions
- IMF transit count data

Open source, MIT licensed, all data sources are free.