### PR TITLE
Update IntoDNS entry: intodns.com → intodns.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ algorithms, knowledgebase and AI technology.
 * [Icann Lookup](https://lookup.icann.org/en/lookup) - The site allows you to look up domain registration information (WHOIS) on the internet
 * [Infosniper](http://www.infosniper.net)
 * [isMalicious](https://ismalicious.com) - Threat intelligence platform aggregating malicious IP and domain data from multiple security feeds with real-time reputation scoring and threat categorization.
-* [intoDNS](http://www.intodns.com)
+* [IntoDNS.ai](https://intodns.ai) - AI-powered DNS and email security scanner with SPF, DKIM, DMARC, DNSSEC checks and fix suggestions.
 * [IP 2 Geolocation](http://ip2geolocation.com)
 * [IP 2 Location](http://www.ip2location.com/demo.aspx)
 * [IP Geolocation API DB-IP](https://db-ip.com) - Pprovides IP geolocation and intelligence.


### PR DESCRIPTION
## Summary

Update the [IntoDNS entry](https://intodns.ai) in the Domain and IP Research section.

The old `intodns.com` is defunct and no longer operational. [IntoDNS.ai](https://intodns.ai) is a modern replacement providing AI-powered DNS and email security analysis including SPF, DKIM, DMARC, and DNSSEC checks with actionable fix suggestions.

**Disclosure:** I maintain IntoDNS.ai (a [Cobytes](https://cobytes.com) product).

## Changes

- Updated URL from `http://www.intodns.com` to `https://intodns.ai`
- Updated name from `intoDNS` to `IntoDNS.ai`
- Added description to match the format of other entries in the list