### PR TITLE
Add Phantom Tide to Maritime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1612,6 +1612,7 @@ algorithms, knowledgebase and AI technology.
 ## [↑](#-table-of-contents) Maritime
 
 * [Hormuz Tracker](https://github.com/johnsmalls22-rgb/hormuz-tracker) - Real-time Strait of Hormuz vessel tracking with AIS data, dark ship detection, oil prices, and carrier positions.
+* [Phantom Tide](https://github.com/tg12/phantomtide) - Cross-domain OSINT dashboard combining vessel tracking, airspace activity, official notices, environmental context, and satellite detections for maritime and airspace analysis.
 * [VesselFinder](https://www.vesselfinder.com) - a FREE AIS vessel tracking web site. VesselFinder displays real time ship positions and marine traffic detected by global AIS network.
 
 ## [↑](#-table-of-contents) Other Tools


### PR DESCRIPTION
This adds Phantom Tide to the Maritime section.

Disclosure: I maintain Phantom Tide and am submitting it for inclusion.

Repository: https://github.com/tg12/phantomtide
Reason for inclusion: it helps analysts correlate vessel tracking, airspace activity, official notices, environmental context, and satellite detections in one workflow.