### PR TITLE
Add PRISM - Open-source OSINT platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,7 @@ algorithms, knowledgebase and AI technology.
 * [Outwit](http://www.outwit.com) - Find, grab and organize all kinds of data and media from online sources.
 * [PGPKeyAnalyser](https://kriztalz.sh/pgp-key-analyser/) - Analyse and view the details of a PGP key online without having to download the asc file.
 * [Photon](https://github.com/s0md3v/Photon) - Crawler designed for OSINT
+* [PRISM](https://github.com/NovaCode37/Prism-platform) - Open-source OSINT platform with 20+ modules, AI analysis, entity graph, GeoIP map, and OPSEC scoring. Self-hosted with Docker.
 * [Pyba](https://github.com/fauvidoTechnologies/PyBrowserAutomation/) - A browser automation framework which requires low-code to search the web and perform OSINT using DFS and BFS modes, ideal for exploratory tasks.
 * [pygreynoise](https://github.com/GreyNoise-Intelligence/pygreynoise) - Greynoise Python Library
 * [QuickCode](https://quickcode.io/) - Python and R data analysis environment.


### PR DESCRIPTION
Added [PRISM](https://github.com/NovaCode37/Prism-platform) to the Other Tools section.

I am the author of this project.

PRISM is an open-source OSINT platform that aggregates 20+ passive reconnaissance modules into a single real-time dashboard. It helps OSINT investigators by combining WHOIS, DNS, certificate transparency, Shodan, VirusTotal, Wayback Machine, username search (Blackbird + Maigret), breach lookup, email verification, and more - all in one scan.

Key features for OSINT work:
- AI-powered findings summary with risk assessment
- Interactive entity relationship graph
- GeoIP mapping with coordinates
- OPSEC exposure scoring (0-100)
- 12/20 modules require zero API keys
- Self-hosted via Docker

Live demo: https://getprism.su
MIT licensed.