### PR TITLE
Add keyFinder to Other Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1637,6 +1637,7 @@ algorithms, knowledgebase and AI technology.
 * [IntelHub](https://github.com/tomsec8/IntelHub) – Browser-based open-source OSINT extension. All analysis runs locally (no servers). Features include text profiler, metadata analyzer, site & archive analysis, reverse image search, crypto/telegram analyzers.
 * [Hunchly](https://www.hunch.ly/) - Hunchly is a web capture tool designed specifically for online investigations.
 * [IntellyWeave](https://github.com/vericle/intellyweave)  - AI-powered OSINT platform with GLiNER entity extraction, Mapbox 3D geospatial visualization, and multi-agent archive research across 30+ international archives.
+* [keyFinder](https://github.com/momenbasel/keyFinder) - Chrome extension that passively discovers leaked API keys, tokens, secrets, and credentials on any web page by scanning scripts, meta tags, hidden fields, web storage, and network responses using 80+ detection patterns and Shannon entropy analysis.
 * [LinkScope Client](https://github.com/AccentuSoft/LinkScope_Client) - LinkScope Client Github repository.
 * [LinkScope](https://accentusoft.com/) - LinkScope is an open source intelligence (OSINT) graphical link analysis tool and automation platform for gathering and connecting information for investigative tasks.
 * [Maltego](https://www.maltego.com/) - Maltego is an open source intelligence (OSINT) and graphical link analysis tool for gathering and connecting information for investigative tasks.


### PR DESCRIPTION
## Summary

- Adds [keyFinder](https://github.com/momenbasel/keyFinder) to the **Other Tools** section (alphabetical order).
- keyFinder is a Chrome extension (MIT license, 556+ stars) that passively discovers leaked API keys, tokens, secrets, and credentials on any web page.
- It scans 10 attack surfaces (scripts, meta tags, hidden fields, web storage, network responses, etc.) using 80+ detection patterns and Shannon entropy analysis.
- Useful for OSINT practitioners to passively identify exposed credentials during web reconnaissance.

**Disclosure:** I am the author of keyFinder.