### PR TITLE
Add Email Extractor and fix minor typos in Email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,12 +736,13 @@ algorithms, knowledgebase and AI technology.
 ## [↑](#-table-of-contents) Email Search / Email Check
 
 * [Blackbird](https://github.com/p1ngul1n0/blackbird) - Search for accounts associated with a given email across various platforms.
-* [Blacklist Checker](https://blacklistchecker.com/) - Blacklist Checker is anemail blacklist checker, monitor and API that checks 100+ blacklists in seconds
+* [Blacklist Checker](https://blacklistchecker.com/) - Blacklist Checker is an email blacklist checker, monitor and API that checks 100+ blacklists in seconds
 * [DeHashed](https://dehashed.com/) - DeHashed helps prevent ATO with our extensive data set & breach notification solution. Match employee and consumer logins against the world’s largest repository of aggregated publicly available assets leaked from third-party breaches. Secure passwords before criminals can abuse stolen information, and protect your enterprise.
 * [Email Address Validator](http://www.email-validator.net)  - Improve deliverability, reduce bounce rates, prevent fraud and minimize funnel leaks.
+* [Email Extractor](https://99tools.net/email-extractor/)  - A browser-based utility to quickly extract email addresses from bulk text or raw data for further investigation.
 * [Email Format](http://email-format.com) - is a website that allows you to find email address formats used by different companies.
 * [Email Permutator](https://www.polished.app/email-permutator/) - a powerful tool designed to aid professionals in generating a range of potential email addresses for a specific contact. 
-* [EmailHippo](https://tools.verifyemailaddress.io) - is an email address verification platform that will check whether a given email address exist or not.
+* [EmailHippo](https://tools.verifyemailaddress.io) - is an email address verification platform that will check whether a given email address exists or not.
 * [EmailRep](https://emailrep.io) - Email address reputation and risk scoring service.
 * [Epieos Tools](https://tools.epieos.com) - Collection of OSINT tools for email investigations.
 * [Ghunt](https://github.com/mxrch/GHunt) - Investigate Google emails and documents.


### PR DESCRIPTION
This contribution adds the Email Extractor tool to the "Email Search / Email Check" section. 

Key changes:
- Added Email Extractor (https://99tools.net/email-extractor/) in alphabetical order.
- Fixed a spacing error in the Blacklist Checker description ("anemail" -> "an email").
- Fixed a grammatical error in the EmailHippo description ("exist" -> "exists").

Disclosure: I am the founder of 99Tools.net. This tool is a client-side, browser-based utility designed to help OSINT researchers quickly extract email addresses from unstructured text or raw data without sending sensitive information to a server.