### PR TITLE
Add ENNA - OSINT tool index with 325+ tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1628,6 +1628,7 @@ algorithms, knowledgebase and AI technology.
 * [CyberGordon](https://cybergordon.com) - CyberGordon is a threat intelligence search engine. It leverages 30+ sources.
 * [CrowdSec](https://github.com/crowdsecurity/crowdsec) - An open source, free, and collaborative IPS/IDS software written in Go, able to analyze visitor behavior & provide an adapted response to all kinds of attacks.
 * [Datasploit](https://github.com/DataSploit/datasploit) - Tool to perform various OSINT techniques on usernames, emails addresses, and domains.
+* [ENNA](https://www.en-na.com) - Curated directory of 325+ open-source OSINT and security tools with live GitHub stats, cheat sheets, starter kits, workflows, and community reviews. [Open Source](https://github.com/1oosedows/enna)
 * [Dehashed CLI](https://github.com/hmaverickadams/DeHashed-API-Tool) - Command-line tool for searching breach databases via DeHashed API.
 * [Discoshell](https://github.com/foozzi/discoshell) - A simple discovery script that uses popular tools like subfinder, amass, puredns, alterx, massdns and others
 * [Dorkgpt](https://www.dorkgpt.com) - Artificial intelligence that generates advanced search queries to find specific or hidden information on the internet.


### PR DESCRIPTION
Adds [ENNA](https://www.en-na.com) to the Other Tools section.

ENNA is a curated, searchable directory of 325+ open-source OSINT and security tools across 19 categories. Features include live GitHub stats, fuzzy search, tool comparisons, cheat sheets, starter kits, workflows, community reviews, and a public API.

**Source:** [github.com/1oosedows/enna](https://github.com/1oosedows/enna)

MIT licensed, actively maintained.