### PR TITLE
Add Snaplert to Web Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1408,6 +1408,7 @@ algorithms, knowledgebase and AI technology.
 * [RSSOwl](http://www.rssowl.org)
 * [Selfoss](http://selfoss.aditu.de)
 * [Silobreaker](http://www.silobreaker.com)
+* [Snaplert](https://snaplert.com) - Visual pixel diffs, AI summaries, and element-level zone picker for monitoring webpage changes. Great for tracking competitor updates.
 * [Talkwalker](http://www.talkwalker.com)
 * [The Old Reader](http://theoldreader.com)
 * [versionista](http://versionista.com)


### PR DESCRIPTION
## What

Adds [Snaplert](https://snaplert.com) to the Web Monitoring section.

## Why

Snaplert is a hosted website change monitoring tool useful for OSINT practitioners who need to track changes on specific sections of pages:

- Visual pixel-level diffs with before/after screenshots
- AI-powered summaries explaining what changed
- Element-level zone picker (monitor a specific part of a page, not the whole thing)
- 5-minute check intervals
- Email + webhook alerts
- Currently free during open beta

This fits alongside existing tools like `visualping`, `versionista`, `ChangeDetection.io`, and `Website-Diff` in the Web Monitoring section. It's particularly useful for tracking competitor pages, policy changes, and public records updates.