### PR TITLE
Add Helium MCP - structured bias scoring API under Fact Checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,6 +1289,7 @@ algorithms, knowledgebase and AI technology.
 
 
 * [Captin Fact](https://captainfact.io/)
+* [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free remote MCP server giving AI assistants (Claude, Cursor) structured 31-dimension bias scores per article (sensationalism, scapegoating, opinion-vs-fact, AI-authorship probability) across 3.2M+ articles from 5,000+ sources. Useful for verification workflows.
 * [Check](https://meedan.com/check)
 * [Emergent](http://www.emergent.info)
 * [Fact Check](http://www.factcheck.org)


### PR DESCRIPTION
Adding [Helium MCP](https://github.com/connerlambden/helium-mcp) under the Fact Checking section.

It's a free, open MCP (Model Context Protocol) server that exposes structured bias analysis to AI assistants like Claude and Cursor. Each article gets scored on 31 dimensions including sensationalism, scapegoating, opinion-vs-fact, credibility, and an AI-authorship probability. 3.2M+ articles from 5,000+ sources.

For OSINT/verification workflows: investigators can paste a URL into Claude and get a structured framing breakdown back, then synthesize across many sources via the `search_balanced_news` endpoint. Free, no signup, one-line setup (`npx mcp-remote https://heliumtrades.com/mcp`).

Thanks for considering!