### PR TITLE
Add ip2geo.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ algorithms, knowledgebase and AI technology.
 * [IP 2 Geolocation](http://ip2geolocation.com)
 * [IP 2 Location](http://www.ip2location.com/demo.aspx)
 * [IP Geolocation API DB-IP](https://db-ip.com) - Pprovides IP geolocation and intelligence.
+* [ip2geo.dev](https://ip2geo.dev) - IP geolocation API providing city, country, timezone, ASN, and currency data from IP addresses.
 * [IP Checking](http://www.ipchecking.com)
 * [IP Location](https://www.iplocation.net) - is used for mapping of an IP address or MAC address to the real-world geographic location of an Internet-connected computing or a mobile device.
 * [IP Location.io](https://iplocation.io) - IPLocation.io allows you to check the location of an IP for free


### PR DESCRIPTION
Added [ip2geo.dev](https://ip2geo.dev) to the Domain and IP Research section.

ip2geo is an IP geolocation API that returns city, country, timezone, ASN, and currency data — useful for OSINT investigations involving IP attribution and geolocation.