### PR TITLE
Add behindtheemail.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Email Search / Email Check
 
+* [Behind the Email](https://behindtheemail.com) - Reverse email lookup that turns any address into an enriched digital footprint.
 * [Blackbird](https://github.com/p1ngul1n0/blackbird) - Search for accounts associated with a given email across various platforms.
 * [Blacklist Checker](https://blacklistchecker.com/) - Blacklist Checker is an email blacklist checker, monitor and API that checks 100+ blacklists in seconds
 * [DeHashed](https://dehashed.com/) - DeHashed helps prevent ATO with our extensive data set & breach notification solution. Match employee and consumer logins against the world’s largest repository of aggregated publicly available assets leaked from third-party breaches. Secure passwords before criminals can abuse stolen information, and protect your enterprise.


### PR DESCRIPTION
Added [behindtheemail.com](https://behindtheemail.com) to the Domain and IP Research section.

Behind the Email is an OSINT platform that instantly turns any email address into a verified public profile, complete with career history, education, photos, and a cross-platform digital footprint.