### PR TITLE
Add Crime Brasil (Data and Statistics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,7 @@ algorithms, knowledgebase and AI technology.
 * [Center for International Earth Science Information Network](http://www.ciesin.org)
 * [CEPII](http://www.cepii.fr/CEPII/en/welcome.asp)
 * [CIA World Factbook](https://www.cia.gov/the-world-factbook/)
+* [Crime Brasil](https://crimebrasil.com.br) - Open-data platform consolidating Brazilian crime statistics (RS neighborhood-level, MG/RJ municipality, national PRF/DATASUS). Free API, CC BY 4.0.
 * [Data.gov.uk](https://data.gov.uk)
 * [DBPedia](http://wiki.dbpedia.org)
 * [European Union Open Data Portal](http://open-data.europa.eu/en/data)


### PR DESCRIPTION
## Adds: [Crime Brasil](https://crimebrasil.com.br)

Inserted alphabetically in **Data and Statistics** between CIA World Factbook and Data.gov.uk.

## What it is

Open-data platform consolidating criminal incidents from Brazilian state police (SSP) sources:

- **Rio Grande do Sul**: ~3M incidents 2022–2025, 99.99% geocoded to neighborhood level (79,024 bairros)
- **Minas Gerais**: ~965K violent crimes, municipality-level
- **Rio de Janeiro**: ~37K ISP/CISP records, municipality-level
- **National**: PRF DATATRAN (federal highway accidents) + DATASUS SINAN (interpersonal violence, 2009–2024)

Free REST API, CSV/Parquet exports, daily updates, CC BY 4.0.

## OSINT relevance

Brazilian public-safety data is notoriously fragmented — SSPs publish inconsistent formats with no geocoding. For anyone doing OSINT on Brazilian localities, Crime Brasil turns raw state-police PDFs into a queryable public dataset.

## Disclosure

I'm the maintainer of Crime Brasil. Submission disclosed per CONTRIBUTING guidelines.