### PR TITLE
Add HackMyIP to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,6 +927,7 @@ algorithms, knowledgebase and AI technology.
 * [Follow.net](http://follow.net)
 * [Fullhunt](https://fullhunt.io/) - FullHunt is an OSINT tool focused on identifying and protecting internet-exposed assets.
 * [GraphyStories](http://app.graphystories.com)
+* [HackMyIP](https://hackmyip.com/) - Free privacy and security toolkit with 19+ tools including IP lookup, DNS lookup, DNS leak test, WebRTC leak test, port scanner, email breach checker, and browser fingerprint analysis. No registration or API key required.
 * [Hudson Rock](https://www.hudsonrock.com/threat-intelligence-cybercrime-tools) - is a free cybercrime intelligence toolkit to check exposure in Infostealer malware infection.
 * [Hybrid Analysis](https://www.hybrid-analysis.com) - Online service for detailed and free analysis of suspicious files and URLs.
 * [HypeStat](https://www.hypestat.com)


### PR DESCRIPTION
## Description

Adding [HackMyIP](https://hackmyip.com/) to the Domain and IP Research section.

HackMyIP is a free online privacy and security toolkit offering 19+ OSINT-relevant tools including:
- IP address lookup & geolocation
- DNS lookup & DNS leak test
- WebRTC leak test
- Port scanner
- Email breach checker
- Browser fingerprint analysis
- WHOIS lookup
- Speed test

All tools are completely free with no registration or API key required, making it a convenient all-in-one resource for OSINT reconnaissance.