### PR TITLE
Add Voidly — global internet censorship intelligence feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,6 +1678,7 @@ algorithms, knowledgebase and AI technology.
 * [REScure Threat Intel Feed](https://rescure.fruxlabs.com/) - REScure is an independent threat intelligence project which we undertook to enhance our understanding of distributed systems, their integration, the nature of threat intelligence and how to efficiently collect, store, consume, distribute it.
 * [STIX Viewer](https://stix-viewer.threatlandscape.io/) - An online free STIX 2.1 viewer / visualizer.
 * [Threat Actor Usernames Scrape](https://github.com/spmedia/Threat-Actor-Usernames-Scrape) - A collection of fresh intel and 450k+ threat actor usernames scraped from various cybercrime sources & forums.
+* [Voidly Censorship Index](https://voidly.ai/censorship-index) - Real-time global internet censorship intelligence aggregating 19.6M live OONI samples and 1.6M historical records across 119+ countries. Provides a citable incident database (5,356 incidents, 16,822 evidence items), an ML-driven shutdown early-warning feed, ISP-level risk scoring, and a public REST/MCP API for blocking, DNS poisoning, and BGP-level outage signals. Data licensed CC BY 4.0.
 
 ## [↑](#-table-of-contents) Gaming Platforms
 


### PR DESCRIPTION
Adds [Voidly Censorship Index](https://voidly.ai/censorship-index) under **Threat Intelligence**.

Voidly is the OSINT layer for nation-state network interference: 19.6M live OONI samples + 1.6M historical records across 119+ countries, surfaced as 5,356 citable incidents with 16,822 evidence items (DNS blocking, TCP-resets, blockpages, BGP-level outages, ISP-specific shutdowns). Useful for journalists, conflict trackers, and researchers needing geo-resolved network-level evidence. Free public REST + MCP API; data is CC BY 4.0.

Entry placed alphabetically (T → V) at the end of the Threat Intelligence list.

maintainer: @EmperorMew