### PR TITLE
Add Voidly CLI to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ algorithms, knowledgebase and AI technology.
 * [Verisign](http://dnssec-debugger.verisignlabs.com)
 * [ViewDNS.info](http://viewdns.info)
 * [Virus Total](https://www.virustotal.com/) - Analyse suspicious domains, IPs URLs and files to detect malware and other breaches
+* [Voidly CLI](https://www.npmjs.com/package/@voidly/cli) - Command-line tool to check if a domain is censored or blocked in a given country. Backed by 19.6M live measurements across 119 countries. `npx @voidly/cli check <domain> <country>`
 * [w3snoop](http://webboar.com.w3snoop.com) - is a website that gives you a free and comprehensive report about a specific website.
 * [Web-Check](https://web-check.as93.net/) - All-in-one tool for viewing website and server meta data.
 * [WebMeUp](http://webmeup.com) - is the Web's freshest and fastest growing backlink index, and the primary source of backlink data for SEO PowerSuite.


### PR DESCRIPTION
Hi! Submitting [Voidly CLI](https://www.npmjs.com/package/@voidly/cli) for the **Domain and IP Research** section.

## What it is
Command-line tool for checking whether a domain is censored or blocked from a given country. Backed by 19.6M live measurements aggregated from OONI, IODA, and CensoredPlanet across 119 countries.

## Why it fits OSINT
- Verify government censorship claims (e.g. is BBC News blocked in Russia? in Iran?)
- Check accessibility of news/social-media domains across jurisdictions
- Pull historical incident timelines for a domain (when did Iran first block twitter.com?)
- Single-command operation, zero config: `npx @voidly/cli check bbc.com IR`

## Format
Added entry alphabetically (between Virus Total and w3snoop).

## Disclosure
I work on Voidly. Per the contributing guidelines: this is a self-promotional submission.