### PR TITLE
Add StaticFuzz to Geospatial Research and Mapping Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,7 @@ algorithms, knowledgebase and AI technology.
 * [Google Maps](https://www.google.com/maps)
 * [Google My Maps](https://www.google.com/maps/about/mymaps)
 * [GPSVisualizer](http://www.gpsvisualizer.com)
+* [StaticFuzz](https://staticfuzz.online) - Forensic analysis platform that converts raw GPS/lat/lng CSV data into court-admissible PDF reports using Haversine velocity analysis. ISO/IEC 27037:2012 compliant, SHA-256 sealed, fully offline.
 * [GrassGIS](http://grass.osgeo.org)
 * [Here](http://here.com)
 * [Hyperlapse](https://github.com/TeehanLax/Hyperlapse.js)


### PR DESCRIPTION
## Tool Submission: StaticFuzz

**Category:** Geospatial Research and Mapping Tools

**URL:** https://staticfuzz.online/

**Description:** StaticFuzz is a forensic analysis platform that ingests raw GPS/lat/lng CSV data and produces a court-admissible PDF intelligence report in under four minutes. It performs Haversine velocity analysis, reconstructs movement timelines, and outputs a SHA-256 sealed report.

**Why it belongs here:**
- Directly processes GPS/geolocation data for investigative purposes
- Produces court-admissible, ISO/IEC 27037:2012 compliant reports
- Used by SIU investigators, private investigators, and digital forensics professionals
- Fully offline, zero-cloud architecture — suitable for sensitive casework

The entry has been placed alphabetically alongside GPSVisualizer in the Geospatial section.