### PR TITLE
Add Asia Fraud Info to Threat Actor Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ algorithms, knowledgebase and AI technology.
 *Search for Threat actors and their associated information.*
 
 * [APT Groups and Operations](https://docs.google.com/spreadsheets/u/0/d/1H9_xaxQHpWaa4O_Son4Gx0YOIzlcBWMsdvePFX68EKU/pubhtml?pli=1#) - Know about Threat Actors, sponsored countries, their tools, methods, etc.
+* [Asia Fraud Info](https://asiafraudinfo.com/) - Searchable Asia-Pacific anti-scam database tracking 44+ impersonation platforms across 10 countries, with 31K+ verified victim cases. [Open dataset](https://asiafraudinfo.com/data).
 * [Bi.Zone](https://gti.bi.zone/) - 148 threat groups with detailed TTPs.
 * [BreachHQ](https://breach-hq.com/threat-actors) - Provides a list of all known cyber threat actors also referred to as malicious actors, APT groups or hackers.
 * [Dark Web Informer](https://darkwebinformer.com/threat-actor-database/) - Tracking 854 Threat Actors as of 29th of May 2025.


### PR DESCRIPTION
Adding Asia Fraud Info to the Threat Actor Search section.

**What it is**: A searchable Asia-Pacific anti-scam intelligence database tracking 44+ impersonation platforms (fake exchanges, fake brokers, romance-scam apps, fake government portals) across 10 countries, with 31,000+ verified victim cases compiled from regulatory enforcement actions and victim reports.

**Why it fits "Threat Actor Search"**:
- One stable URL per impersonation platform → directly searchable threat-actor profile
- Cross-references the same scam operation across regulatory advisories from multiple jurisdictions (HKMA, MAS, FSC Korea, JFSA, Taiwan FSC, ASIC, etc.)
- Open dataset with schema.org Dataset markup + 6 download distributions for OSINT tooling
- 5-language coverage (EN / 简体 / 繁體 / 日本語 / 한국어) — useful for tracking regional scam operations

**Key links**:
- Main site: https://asiafraudinfo.com/
- Open dataset: https://asiafraudinfo.com/data
- Per-platform deep links: https://asiafraudinfo.com/platforms

The entry follows the existing `*` prefix and ` - ` separator format used in the section, and is placed alphabetically between `APT Groups and Operations` and `Bi.Zone`.

Thanks for maintaining this list!