### PR TITLE
Add insto — interactive Instagram OSINT CLI/REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ algorithms, knowledgebase and AI technology.
 * [Iconosquare](http://iconosquare.com)
 * [instagram_monitor](https://github.com/misiektoja/instagram_monitor) - Tool for real-time tracking of Instagram users' activities and profile changes with support for email alerts, CSV logging, showing media in the terminal, anonymous story downloads and more
 * [InstagramPrivSniffer](https://github.com/obitouka/InstagramPrivSniffer) - Views Instagram PRIVATE ACCOUNT'S media without login 😱.
+* [insto](https://github.com/subzeroid/insto) - Interactive OSINT CLI / REPL with 35+ slash-commands: profile + media + followers + dossier + geo-fingerprint (`/where`), shared-followers intersection (`/intersect`), superfan ranking (`/fans`), location search (`/place`), URL→metadata resolution (`/postinfo`), posting-cadence histogram (`/timeline`), Maltego CSV export. Token-based (HikerAPI, no IG account needed → no ban risk) with optional logged-in `aiograpi` backend.
 * [Osintgram](https://github.com/Datalux/Osintgram) - Osintgram offers an interactive shell to perform analysis on Instagram account of any users by its nickname.
 * [Osintgraph](https://github.com/XD-MHLOO/Osintgraph) - Tool that maps your target’s Instagram data and relationships in Neo4j for social network analysis. 
 * [Toutatis](https://github.com/megadose/toutatis) - a tool that allows you to extract information from instagrams accounts such as s, phone numbers and more


### PR DESCRIPTION
Adding [insto](https://github.com/subzeroid/insto) under **Social Media Tools → Instagram**, alphabetised between `InstagramPrivSniffer` and `Osintgram`.

> The name is the same five letters as **OSINT**, rearranged — Instagram tool, OSINT-discipline. Both readings are intentional.

## What it is

Interactive OSINT CLI / REPL with 35+ slash-commands wrapping Instagram's public surface. Token-based against [HikerAPI](https://hikerapi.com) (no Instagram account required → no ban risk) with an optional logged-in [aiograpi](https://github.com/subzeroid/aiograpi) backend for private profiles you follow.

## Highlights vs the existing Instagram entries

- **Geo-fingerprint** (`/where`) — anchor place + GPS centroid + max radius across recent geotagged posts.
- **Cross-target intersection** (`/intersect`) — followers(@a) ∩ followers(@b) for shared-audience analysis.
- **Superfan ranking** (`/fans`) — likes + 3×comments weighted score across recent posts.
- **Location search** (`/place` / `/placeposts`) — text → IG location pk → top media there.
- **URL → metadata** (`/postinfo`) — paste a permalink, get the full Post DTO. Evidence collection.
- **Maltego CSV export** on every entity-shaped command.
- **`/dossier`** — full target package (profile + media + network + analytics) into a structured directory with MANIFEST.md.

PyPI: `pip install insto` · License: MIT · Python ≥ 3.11.

## Disclosure

Per the CONTRIBUTING guideline (*"If your submission is self-promotional or you are related to/work for the website, disclose that up front"*): I maintain `insto` as well as the [HikerAPI](https://hikerapi.com) backend service and the [aiograpi](https://github.com/subzeroid/aiograpi) library it optionally uses. Listing only `insto` here — the other two are infrastructure/library dependencies, not separate Instagram OSINT tools.