### PR TITLE
Add GitLeak to the list of OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ algorithms, knowledgebase and AI technology.
 * [github_monitor](https://github.com/misiektoja/github_monitor) - Tool for real-time tracking of GitHub users' activities including profile and repository changes with support for email alerts, CSV logging, detection when a user blocks or unblocks you and more
 * [GithubRecon](https://kriztalz.sh/github-recon/) - Lookup Github users by username or email and gather associated data.
 * [Shotstars](https://github.com/snooppr/shotstars) - An advanced tool for checking GitHub repositories, with star statistics, including fake star analysis and data visualization.
+* [GitLeak](https://gitleak.io) - An OSINT tool for GitHub that scans user profiles to find leaked email addresses, commit timezones, and activity patterns.
 
 ## [↑](#-table-of-contents) Blog Search
 


### PR DESCRIPTION
Adding GitLeak (https://gitleak.io), a free tool built for extracting emails and commit timezones from GitHub .patch metadata.

<img width="1131" height="934" alt="image" src="https://github.com/user-attachments/assets/d8687893-493a-45e5-85af-d55e941910ff" />
