### PR TITLE
Add GitLeak to GitHub OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ algorithms, knowledgebase and AI technology.
 
 * [github_monitor](https://github.com/misiektoja/github_monitor) - Tool for real-time tracking of GitHub users' activities including profile and repository changes with support for email alerts, CSV logging, detection when a user blocks or unblocks you and more
 * [GithubRecon](https://kriztalz.sh/github-recon/) - Lookup Github users by username or email and gather associated data.
+* [GitLeak](https://gitleak.io) - An OSINT tool for GitHub that extracts hidden email addresses, commit timezones, and activity patterns via .patch metadata.
 * [Shotstars](https://github.com/snooppr/shotstars) - An advanced tool for checking GitHub repositories, with star statistics, including fake star analysis and data visualization.
 
 ## [↑](#-table-of-contents) Blog Search


### PR DESCRIPTION
I am submitting a new tool for the GitHub OSINT section.

Link: [https://gitleak.io](https://gitleak.io/)

Disclosure: As per the contribution guidelines, I am disclosing that I am the creator and developer of this tool. It is completely free to use.

How this helps people doing OSINT:
Investigators often run into anonymous GitHub profiles with no public contact info. GitLeak automates the extraction of hidden email addresses and commit timezones by scraping the metadata baked into a user's .patch files (which occurs when there's a disconnect between their local git config and web UI privacy settings).

I've checked for trailing whitespaces and alphabetical ordering. Thank you for reviewing!