### PR TITLE
Add OsintCat to Data Breach Search Engines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ algorithms, knowledgebase and AI technology.
 * [IKnowYour.Dad](https://iknowyour.dad/) - Data Breach Search Engine.
 * [Leaker](https://github.com/vflame6/leaker) - Passive leak enumeration CLI tool that searches across 10 breach databases simultaneously.
 * [NOX](https://github.com/nox-project/nox-framework) - Recursive async framework for deep breach analysis and identity pivoting.
+* [OsintCat](https://www.osintcat.net/) - Check if an email address has been exposed in known data breaches. Fast lookup across multiple breach databases, with a simple API available.
 * [StealSeek](https://stealseek.io/) - Powerful search engine designed to help you find and analyze data breaches.
 * [Venacus](https://venacus.com/) - Search for your data breaches and get notified when your data is compromised.
 


### PR DESCRIPTION
Adds [OsintCat](https://www.osintcat.net/) to the **Data Breach Search Engines** section.

OsintCat is a data breach lookup tool that lets users check if an email address has appeared in known data breaches. It covers multiple breach databases and provides both a web interface and an API for developers.