### PR TITLE
Add ScanSearch under Speciality Search Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ algorithms, knowledgebase and AI technology.
 * [ODIN](https://search.odin.io/) - Used to search for Hosts, CVEs & Exposed Buckets/Files and shows a website is vulnerable or not. 10 Free Searches Per Day. 
 * [OCCRP Aleph](https://aleph.occrp.org/)
 * [ONYPHE](https://search.onyphe.io/) - OSINT engine indexing exposed assets and services across the internet.
+* [ScanSearch](https://scansearch.net/) - On-demand internet scanner. Trigger live SYN+service scans of any IP, CIDR or country via REST API; free tier and Python SDK.
 * [Search Abuseipdb](https://github.com/oseasfr/search-abuseipdb) - Tool to query IPs, ranges and ASN blocks in AbuseIPDB via API with CIDR notation.
 * [Shadowserver](https://dashboard.shadowserver.org/) - Dashboard with global statistics on cyber threats collected by the Shadowserver Foundation.
 * [Shodan](https://www.shodan.io/) - Shodan is a search engine for the IOT(Internet of Things) that allows you to search variety of servers that are connected to the internet using various searching filters.


### PR DESCRIPTION
Adds [ScanSearch](https://scansearch.net) under **Speciality Search Engines** (alphabetically before Search Abuseipdb, near Censys/Shodan/ZoomEye/FOFA).

ScanSearch is a **live** internet scanner — different from indexed search engines like Shodan/Censys. Instead of querying a cached snapshot, you trigger a real SYN + service scan of any target you specify (IP, CIDR, country code or domain) via the web UI or REST API and get current results in seconds.

Useful for OSINT/recon workflows where the freshness of port/service data matters at the moment of investigation.

- Free tier with no card, paid plans start at \$30/mo
- REST API + official Python SDK at https://github.com/ScanSearch/scansearch-python
- Crypto checkout supported (Coingate)