### PR TITLE
Add Related Repos link to GitHub section

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ algorithms, knowledgebase and AI technology.
 * [github_monitor](https://github.com/misiektoja/github_monitor) - Tool for real-time tracking of GitHub users' activities including profile and repository changes with support for email alerts, CSV logging, detection when a user blocks or unblocks you and more
 * [GithubRecon](https://kriztalz.sh/github-recon/) - Lookup Github users by username or email and gather associated data.
 * [GitLeak](https://gitleak.io) - An OSINT tool for GitHub that extracts hidden email addresses, commit timezones, and activity patterns via .patch metadata.
+* [Related Repos](https://relatedrepos.com/) - Discover related open source projects. Find alternatives and other similar repositories. Updated daily.
 * [Shotstars](https://github.com/snooppr/shotstars) - An advanced tool for checking GitHub repositories, with star statistics, including fake star analysis and data visualization.
 
 ## [↑](#-table-of-contents) Blog Search


### PR DESCRIPTION
Disclosure: As per the contribution guidelines, I am disclosing that I am the creator and developer of this tool. It is completely free to use.

[Related Repos](https://relatedrepos.com/) helps developers to discover open source projects that are related to each other. This can be useful to find alternative or complementary packages when building a full application. Or you can simply surf around in different neighborhoods to find new ideas that you might not have been aware of.

Data and results are updated daily so you can keep coming back to discover fresh repositories. Results can be thought of as "users who expressed interest in this repository also expressed interest in these other repositories".