### PR TITLE
Add Emailcheckerr to Email Search / Email Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ algorithms, knowledgebase and AI technology.
 * [Email Extractor](https://99tools.net/email-extractor/)  - A browser-based utility to quickly extract email addresses from bulk text or raw data for further investigation.
 * [Email Format](http://email-format.com) - is a website that allows you to find email address formats used by different companies.
 * [Email Permutator](https://www.polished.app/email-permutator/) - a powerful tool designed to aid professionals in generating a range of potential email addresses for a specific contact. 
+* [Emailcheckerr](https://emailcheckerr.com) - Bulk SMTP email verification (syntax, MX, RCPT-level deliverability checks); useful for confirming whether an investigated address actually exists.
 * [EmailHippo](https://tools.verifyemailaddress.io) - is an email address verification platform that will check whether a given email address exists or not.
 * [EmailRep](https://emailrep.io) - Email address reputation and risk scoring service.
 * [Epieos Tools](https://tools.epieos.com) - Collection of OSINT tools for email investigations.


### PR DESCRIPTION
Adding **Emailcheckerr** to the Email Search / Email Check section.

* Format: `* [Emailcheckerr](https://emailcheckerr.com) - Bulk SMTP email verification (syntax, MX, RCPT-level deliverability checks); useful for confirming whether an investigated address actually exists.`
* Inserted alphabetically between *Email Permutator* and *EmailHippo*.

**OSINT relevance:** confirms whether an investigated email address exists at the SMTP level (RCPT TO probe, no DATA sent), without tipping off the owner. Sits alongside existing entries like *Email Address Validator*, *EmailHippo*, *Reacher*, *Verify Email*.

**Disclosure:** I'm related to the project (per CONTRIBUTING.md guideline #14).

Checklist:
- [x] Read the awesome manifesto
- [x] Searched previous suggestions — no duplicate
- [x] Inserted alphabetically
- [x] Single suggestion in this PR
- [x] Self-promotion disclosed