### PR TITLE
Add TweetClaw to Twitter tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ algorithms, knowledgebase and AI technology.
 * [Tagdef](https://tagdef.com)
 * [Trends24](http://trends24.in)
 * [TwChat](http://twchat.com)
+* [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - OpenClaw plugin and npm package for tweet search, user lookup, follower export, reply and quote extraction, account monitoring, and structured X/Twitter data collection via Xquik.
 * [TweetMap](http://mapd.csail.mit.edu/tweetmap)
 * [TweetMap](http://worldmap.harvard.edu/tweetmap)
 * [Twitter Advanced Search](https://twitter.com/search-advanced?lang=en)


### PR DESCRIPTION
Disclosure: I maintain TweetClaw and Xquik.

## Summary
- add TweetClaw to the Twitter section as a separate open source OpenClaw plugin entry
- describe the investigative jobs it is useful for: tweet search, user lookup, follower export, reply and quote extraction, and account monitoring
- keep the existing README bullet format and alphabetical placement

## Validation
- read README and CONTRIBUTING.md
- checked prior PR and issue history for TweetClaw and Xquik duplicates
- ran `git diff --check`

Link: https://github.com/Xquik-dev/tweetclaw
