### PR TITLE
Add Domain Intelligence to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,7 @@ algorithms, knowledgebase and AI technology.
 * [DNSViz](http://dnsviz.net)
 * [Domain Crawler](http://www.domaincrawler.com)
 * [Domain Dossier](http://centralops.net/co/DomainDossier.aspx)
+* [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) - Aggregate DNS, WHOIS/RDAP, SSL, subdomains (CT logs + DNS bruteforce), and SPF/DMARC posture in one call. Free tier; MIT.
 * [DomainRecon](https://kriztalz.sh/domain-recon/) - Retrieve DNS records, subdomains, SSL certificates and WHOIS / RDAP data for a given website.
 * [Domain Tools](http://whois.domaintools.com) - Whois lookup and domain/ip historical data.
 * [Easy whois](https://www.easywhois.com)


### PR DESCRIPTION
Adds Domain Intelligence to the Domain and IP Research section.

Single-call API that aggregates DNS, WHOIS/RDAP, SSL certificate inspection, subdomain enumeration via Certificate Transparency logs (with DNS bruteforce fallback), and SPF/DMARC posture.

- Free tier (1,000 req/mo) via RapidAPI
- Public no-signup demo (5/IP/day) on the landing page: https://oti-labs.com/domain-intelligence-api
- Command-line: `curl https://oti-labs.com/demo/example.com | jq`
- Source: https://github.com/osiris-technical-institute/domain-intelligence-api (MIT)

Disclosure: I work on the project. Adding it because the use case overlaps directly with the existing DomainRecon entry that sits right next to where this would alphabetically slot.