### PR TITLE
Add Warnely to Data and Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1359,6 +1359,7 @@ algorithms, knowledgebase and AI technology.
 * [Upsala Conflict Data Program](http://www.pcr.uu.se/research/UCDP)
 * [US Data and Statistics](https://www.usa.gov/statistics)
 * [Vizala](https://vizala.com)
+* [Warnely](https://warnely.com/developers) - Composite travel-safety statistics for 180 countries combining UK FCDO + US State Department advisories, Global Peace Index, World Bank Worldwide Governance Indicators, and a live news incident wire. Free REST API + OpenAPI 3.1 spec, CC BY 4.0.
 * [WHO Data](http://www.who.int/gho/en)
 * [World Bank Data](http://data.worldbank.org)
 * [World Bank Data](http://datatopics.worldbank.org/consumption/home)


### PR DESCRIPTION
Adds [Warnely](https://warnely.com/developers) to the **Data and Statistics** section, placed alphabetically between Vizala and WHO Data.

## OSINT relevance

Warnely is a composite country-risk dataset combining:

- UK FCDO travel advisories (daily-refreshed scrape)
- US State Department travel advisories (daily-refreshed scrape)
- Global Peace Index 2025
- World Bank Worldwide Governance Indicators
- Live news incident wire (Reuters, BBC, AP, AFP, USGS, GDACS, ReliefWeb)

For OSINT use cases, the dataset surfaces:

- Cross-country risk comparison without manual scraping of FCDO/State Dept HTML
- Live incident feed with location, severity, and category classification
- Per-country drug-law tier, LGBTQ+ legal status, women's safety rating
- Geographic centroid for risk mapping

## API

- **Base URL**: https://warnely.com/api/v1
- **Interactive docs**: https://warnely.com/api-docs
- **OpenAPI 3.1 spec**: https://warnely.com/openapi.json
- **Auth**: None
- **License**: CC BY 4.0

## Sample

```
curl https://warnely.com/api/v1/incidents/recent
```

Returns the most recent items from the safety-incident wire, classified by category and severity.