### PR TITLE
Add GHNames tool to GitHub category

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ algorithms, knowledgebase and AI technology.
 
 ### [↑](#-table-of-contents) GitHub
 
+* [GHNames](https://ghnames.com/) - GitHub lookup tool to search for username history, associated emails, and deleted repositories.
 * [github_monitor](https://github.com/misiektoja/github_monitor) - Tool for real-time tracking of GitHub users' activities including profile and repository changes with support for email alerts, CSV logging, detection when a user blocks or unblocks you and more
 * [GithubRecon](https://kriztalz.sh/github-recon/) - Lookup Github users by username or email and gather associated data.
 * [GitLeak](https://gitleak.io) - An OSINT tool for GitHub that extracts hidden email addresses, commit timezones, and activity patterns via .patch metadata.


### PR DESCRIPTION
This pull request adds [GHNames](https://ghnames.com/) to the GitHub section of the list. 

### Why this helps OSINT
GHNames allows investigators to look up a GitHub username and surface historical account data that is otherwise difficult to track down. It is highly useful for tracing developer footprints, finding scrubbed data, and pivoting to associated email addresses.

**Key Features:**
* **Username history:** Returns historical usernames and the dates they were first seen.
* **Email correlation:** Returns a list of emails potentially associated with the account, the number of times they were seen associated with the account, and a confidence score that the email actually belongs to that user.
* **Repository diffs:** Returns a diff of all current and historical repositories. Red highlighting indicates a repository that was deleted and no longer exists.

**Database Stats:**
* 95 Million usernames
* 142 Million email addresses
* 674 Million repositories

### Preview
<img width="1056" height="625" alt="Image" src="https://github.com/user-attachments/assets/f1cdfa40-98b8-4793-9fb3-0869bff3a669" />

### Proposed Entry 
*(To be inserted alphabetically in the GitHub section)*

- [GHNames](https://ghnames.com/) - GitHub lookup tool to search for username history, associated emails, and deleted repositories.

---
*Disclosure: I am a contributor to this project, However it is completely free to use and non-profit.*