### PR TITLE
Add phinn.app to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,7 @@ algorithms, knowledgebase and AI technology.
 * [OpenLinkProfiler](http://www.openlinkprofiler.org/)
 * [PageGlimpse](http://www.pageglimpse.com)
 * [Pentest-Tools.com](https://pentest-tools.com/information-gathering/google-hacking) - uses advanced search operators (Google Dorks) to find juicy information about target websites.
+* [phinn.app](https://phinn.app/) - Free public phishing-link scanner that detonates URLs in an isolated sandbox and returns an AI-driven verdict; opt-in public trends and a free /v1/scan API.
 * [PhishStats](https://phishstats.info/)
 * [Pulsedive](https://pulsedive.com)
 * [Qualys SSL Check](https://www.ssllabs.com/ssltest/) - SSL Test configuration compliance.


### PR DESCRIPTION
Adds phinn.app, a free public phishing-link scanner, to the Domain and IP Research section (alphabetical placement between Pentest-Tools.com and PhishStats).

phinn.app detonates submitted URLs in an isolated sandbox and produces an AI-driven verdict. Individual scans stay private to the submitter; aggregate trends are opt-in and published at https://phinn.app/trends. Free public API at /v1/scan, methodology at https://phinn.app/methodology.