### PR TITLE
Add MyIPNow to list of online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,6 +959,7 @@ algorithms, knowledgebase and AI technology.
 * [Mark Monitor WHOIS](https://whois-webform.markmonitor.com/whois/) - Displays domain registration information.
 * [MaxMind](https://www.maxmind.com)
 * [MetaDefender](https://metadefender.com) - Threat analysis service for URLs, files, certificates, domains, and suspicious hashes.
+* [MyIPNow](https://myipnow.net) - Free IP lookup, DNS, WHOIS, blacklist check, subnet calculator and ASN lookup tools with browser extension.
 * [Netcraft Site Report](http://toolbar.netcraft.com/site_report?url=undefined#last_reboot) - is an online database that will provide you a report with detail information about a particular website and the history associated with it.
 * [OpenLinkProfiler](http://www.openlinkprofiler.org/)
 * [PageGlimpse](http://www.pageglimpse.com)


### PR DESCRIPTION
Adding myipnow.net - a free web toolkit covering IP lookup/geolocation, DNS lookup, WHOIS, IP blacklist check, ASN lookup, subnet calculator, ping test and speed test. Also available as Chrome and Firefox browser extensions.