### PR TITLE
Add IGDetective to Social Media Tools > Instagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ algorithms, knowledgebase and AI technology.
 
 * [Dolphin Radar](https://www.dolphinradar.com/web-viewer-for-instagram) - An Instagram Post Viewer lets you view posts, stories, and profiles from public accounts with ease. Free viewer limit: 1.
 * [Iconosquare](http://iconosquare.com)
+* [IGDetective](https://www.igdetective.com) - Investigates public Instagram accounts without logging in: chronological recent follows/unfollows, most-frequent interactions, and anonymous story viewing, plus an AI assistant that summarizes an account's recent activity.
 * [instagram_monitor](https://github.com/misiektoja/instagram_monitor) - Tool for real-time tracking of Instagram users' activities and profile changes with support for email alerts, CSV logging, showing media in the terminal, anonymous story downloads and more
 * [InstagramPrivSniffer](https://github.com/obitouka/InstagramPrivSniffer) - Views Instagram PRIVATE ACCOUNT'S media without login 😱.
 * [insto](https://github.com/subzeroid/insto) - Interactive OSINT CLI / REPL with 35+ slash-commands: profile + media + followers + dossier + geo-fingerprint (`/where`), shared-followers intersection (`/intersect`), superfan ranking (`/fans`), location search (`/place`), URL→metadata resolution (`/postinfo`), posting-cadence histogram (`/timeline`), Maltego CSV export. Token-based (HikerAPI, no IG account needed → no ban risk) with optional logged-in `aiograpi` backend.


### PR DESCRIPTION
Adds IGDetective (https://www.igdetective.com) under Social Media Tools > Instagram.

**How it helps OSINT:** IGDetective works on any public Instagram account with no login and no footprint on the target. It surfaces who an account recently followed and unfollowed in chronological order, who it interacts with most, and lets you view public Stories anonymously — useful SOCMINT signals for mapping an account's connections and recent activity. It also includes an AI assistant that summarizes a profile's recent public activity.

Inserted alphabetically in the Instagram section (after Iconosquare).

**Disclosure:** I work on IGDetective, so this is a self-promotional submission — flagging per CONTRIBUTING.md. Happy to adjust the wording or remove it if it doesn't meet the bar.
