### PR TITLE
Add TwitterAPI.io to Twitter section

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ algorithms, knowledgebase and AI technology.
 * [TweetMap](http://mapd.csail.mit.edu/tweetmap)
 * [TweetMap](http://worldmap.harvard.edu/tweetmap)
 * [Twitter Advanced Search](https://twitter.com/search-advanced?lang=en)
+* [TwitterAPI.io](https://twitterapi.io) - Real-time X (Twitter) data API for OSINT investigations — historical tweet search, profile lookup, follower/following extraction, account monitoring. From $0.15 per 1K tweets.
 * [Twitter Audit](https://www.twitteraudit.com)
 * [Twitter Chat Schedule](http://tweetreports.com/twitter-chat-schedule)
 * [Twitter Search](http://search.twitter.com)


### PR DESCRIPTION
Adds the TwitterAPI.io real-time Twitter/X data API to the **Twitter** subsection (alphabetical, after Twitter Search, before Xquik).

- URL: https://twitterapi.io
- 12 read-only tools relevant for OSINT: search tweets, get user info, followers/followings, mentions, replies, quotes, retweeters, trends.
- Single API key, no OAuth, pay-per-call.
- Also delivered as a hosted MCP server at mcp.twitterapi.io/mcp for AI-assisted investigations.

Not previously listed. Followed the section's `* [Name](url) - description` format.