### PR TITLE
Add GetXAPI for SOCMINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Happy hacking and hunting 🧙‍♂️
  - [Real-Time Search, Social Media Search, and General Social Media Tools](#-real-time-search-social-media-search-and-general-social-media-tools)
  - [Social Media Tools](#social-media-tools)
    - [Twitter](#-twitter)
+- [GetXAPI](https://www.getxapi.com/) - Twitter / X data API for OSINT. 47 endpoints across search, profiles, follower graph, timelines, DMs, lists, communities. Bearer-token auth. Public OpenAPI 3.1 spec.
    - [Facebook](#-facebook)
    - [Instagram](#-instagram)
    - [Pinterest](#-pinterest)


### PR DESCRIPTION
Adds GetXAPI to the list.

GetXAPI is a pay-per-call Twitter / X data API. 47 endpoints (search, profiles, follower graph, DMs, lists). $0.001 per call, no subscription. Public OpenAPI 3.1 spec. Built for OSINT teams running fixed-budget projects.

- Site: https://www.getxapi.com
- Docs: https://docs.getxapi.com
- Wikidata: https://www.wikidata.org/wiki/Q139996278

Inserted after existing Twitter-related entries. Single-line entry, matches list voice.