### PR TITLE
Add xfetch to Social Media Tools > Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ algorithms, knowledgebase and AI technology.
 * [Twitter Audit](https://www.twitteraudit.com)
 * [Twitter Chat Schedule](http://tweetreports.com/twitter-chat-schedule)
 * [Twitter Search](http://search.twitter.com)
+* [xfetch](https://xfetch.io) - API for X/Twitter read workflows: tweet & profile search, account intelligence, tweet context, and relationship-graph data via REST endpoints.
 * [Xquik](https://xquik.com) - Real-time X (Twitter) data platform for tweet search, user lookup, follower/following extraction, engagement metrics, account monitoring, reply/retweet/quote extraction, community & Space data, and mutual follow checks.
 
 ### [↑](#-table-of-contents) Facebook


### PR DESCRIPTION
Adds **xfetch** ([xfetch.io](https://xfetch.io)) to the *Social Media Tools → Twitter* section, alphabetically before the existing Xquik entry.

xfetch is a developer API for X/Twitter read workflows — tweet & profile search, account intelligence, tweet context, and relationship-graph data — via stable REST endpoints. Useful for OSINT collection and monitoring workflows.

Entry follows the section's existing bullet format.