### PR TITLE
Add Geonode to Other Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1638,6 +1638,7 @@ algorithms, knowledgebase and AI technology.
 * [FaviconHash](https://kriztalz.sh/favicon-hash/) - Generate favicon hashes of a website for use on Shodan, VirusTotal, Censys, ZoomEye or FOFA.
 * [Find osint tool](https://find.osint-tool.com) - Searches multiple OSINT tools to find information across various sources.
 * [FOCA](https://github.com/ElevenPaths/FOCA) - Tool to find metadata and hidden information in the documents.
+* [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
 * [Glit](https://github.com/shadawck/glit) -  Retrieve all mails of users related to a git repository, a git user or a git organization.
 * [Greynoise](https://greynoise.io/) - "Anti-Threat Intelligence" Greynoise characterizes the background noise of the internet, so the user can focus on what is actually important.
 * [IntelHub](https://github.com/tomsec8/IntelHub) – Browser-based open-source OSINT extension. All analysis runs locally (no servers). Features include text profiler, metadata analyzer, site & archive analysis, reverse image search, crypto/telegram analyzers.

--- a/README.md
+++ b/README.md
@@ -1638,7 +1638,7 @@ algorithms, knowledgebase and AI technology.
 * [FaviconHash](https://kriztalz.sh/favicon-hash/) - Generate favicon hashes of a website for use on Shodan, VirusTotal, Censys, ZoomEye or FOFA.
 * [Find osint tool](https://find.osint-tool.com) - Searches multiple OSINT tools to find information across various sources.
 * [FOCA](https://github.com/ElevenPaths/FOCA) - Tool to find metadata and hidden information in the documents.
-* [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
+* [Geonode](https://geonode.com) - Rotating residential and datacenter proxies with REST API access.
 * [Glit](https://github.com/shadawck/glit) -  Retrieve all mails of users related to a git repository, a git user or a git organization.
 * [Greynoise](https://greynoise.io/) - "Anti-Threat Intelligence" Greynoise characterizes the background noise of the internet, so the user can focus on what is actually important.
 * [IntelHub](https://github.com/tomsec8/IntelHub) – Browser-based open-source OSINT extension. All analysis runs locally (no servers). Features include text profiler, metadata analyzer, site & archive analysis, reverse image search, crypto/telegram analyzers.


### PR DESCRIPTION
I run Geonode. Adding us to the **Other Tools** list. Geonode does residential + datacenter proxies, fits next to apify.

Proposed entry:
```
- [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.