### PR TITLE
Improve OSINT Projects entry (alphabetical order + clearer description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,7 +911,6 @@ algorithms, knowledgebase and AI technology.
 ## [↑](#-table-of-contents) Domain and IP Research
 
 * [aa419 Fake Sites Database](https://db.aa419.org/fakebankslist.php) - The site lists fraudulent websites, such as fake banks and online scams, identified by the Artists Against 419 community.
-* [OSINT Projects](https://osintprojects.com/) - This site provide multiple Domain & IP OSINT free Useful tools.
 * [Accuranker](https://www.accuranker.com)
 * [ahrefs](https://ahrefs.com) - A tool for backlink research, organic traffic research, keyword research, content marketing & more.
 * [Azure Tenant Resolution by PingCastle](https://tenantresolution.pingcastle.com) - Search for Azure Tenant using its domain name or its ID
@@ -961,6 +960,7 @@ algorithms, knowledgebase and AI technology.
 * [MetaDefender](https://metadefender.com) - Threat analysis service for URLs, files, certificates, domains, and suspicious hashes.
 * [Netcraft Site Report](http://toolbar.netcraft.com/site_report?url=undefined#last_reboot) - is an online database that will provide you a report with detail information about a particular website and the history associated with it.
 * [OpenLinkProfiler](http://www.openlinkprofiler.org/)
+* [OSINT Projects](https://osintprojects.com) - Free, no-signup tools for WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery.
 * [PageGlimpse](http://www.pageglimpse.com)
 * [Pentest-Tools.com](https://pentest-tools.com/information-gathering/google-hacking) - uses advanced search operators (Google Dorks) to find juicy information about target websites.
 * [PhishStats](https://phishstats.info/)

--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ algorithms, knowledgebase and AI technology.
 ## [↑](#-table-of-contents) Domain and IP Research
 
 * [aa419 Fake Sites Database](https://db.aa419.org/fakebankslist.php) - The site lists fraudulent websites, such as fake banks and online scams, identified by the Artists Against 419 community.
+* [OSINT Projects](https://osintprojects.com/) - This site provide multiple Domain & IP OSINT free Useful tools.
 * [Accuranker](https://www.accuranker.com)
 * [ahrefs](https://ahrefs.com) - A tool for backlink research, organic traffic research, keyword research, content marketing & more.
 * [Azure Tenant Resolution by PingCastle](https://tenantresolution.pingcastle.com) - Search for Azure Tenant using its domain name or its ID


### PR DESCRIPTION
The OSINT Projects entry was placed at the top of the *Domain and IP Research* list (out of alphabetical order) and had an unclear description. This moves it into alphabetical position (after OpenLinkProfiler) and rewords it to clearly describe the tools it offers: WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery. No new link added — this only improves the existing entry.