### PR TITLE
Add Lullar — free people search across 170+ platforms (Email Search + Username Check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ algorithms, knowledgebase and AI technology.
 * [Cupidcr4wl](https://github.com/OSINTI4L/cupidcr4wl) - Username and phone number search tool that crawls adult content platforms to see if a targeted account or person is present.
 * [Digital Footprint Check](https://www.digitalfootprintcheck.com/free-checker.html)  - Check for registered username on 100s of sites for free.
 * [IDCrawl](https://www.idcrawl.com/username) - Search for a username in popular social networks.
+* [Lullar](https://com.lullar.com) - Free username search across 170+ social media platforms — returns direct profile links instantly, supports email and name input too.
 * [Maigret](https://github.com/soxoj/maigret) - Collect a dossier on a person by username.
 * [Name Chk](http://www.namechk.com) - Check over 30 domains and more than 90 social media account platforms.
 * [Name Checkr](http://www.namecheckr.com) - checks a domain and username across many platforms.
@@ -753,6 +754,7 @@ algorithms, knowledgebase and AI technology.
 * [IntelBase](https://intelbase.is/) - Forensics platform focused on reverse email lookup and email data enrichment.
 * [LeakCheck](https://leakcheck.io/) - Data Breach Search Engine with 7.5B+ entries collected from more than 3000 databases. Search by e-mail, username, keyword, password or corporate domain name.
 * [LeakRadar](https://leakradar.io/) - Scans for compromised emails and domains in stealer logs, offering proactive breach prevention and real-time alerts.
+* [Lullar](https://com.lullar.com) - Free people search by email, name or username across 170+ social media platforms, with results returned as direct profile links. No sign-up required.
 * [MailAccess](https://github.com/KatrielMoses/MailAccess) - Free email OSINT tool, checks 800+ platforms, breach exposure via HIBP, infostealer logs via Hudson Rock, and builds a cross-platform identity graph with confidence scoring. `pip install mailaccess`
 * [MailTester](http://mailtester.com) - hunt for emails and improve your email deliverability
 * [Minerva OSINT](https://minervaosint.com) - Email search tool that finds and aggregates data on a target email from over a hundred websites.


### PR DESCRIPTION
## What

Adds **[Lullar](https://com.lullar.com)** to two relevant sections, alphabetically:

- **Email Search / Email Check**
- **Username Check**

## Why it belongs here

- Free people-search engine operating since **2008** — searches **170+ social media platforms** by email, name, or username in one query
- Returns **direct profile links** (not just yes/no existence checks like most username checkers)
- No sign-up, no rate-limit for normal use, works in 22 languages
- Complements existing tools: where Sherlock/Maigret are CLI tools requiring install, Lullar is instant in-browser — useful for quick triage before deeper CLI work

## Notes

- Entries follow the existing format and alphabetical ordering of both sections
- One-line descriptions match surrounding entry style

🤖 Generated with [Claude Code](https://claude.com/claude-code)