### PR TITLE
Add Subhunt to DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1615,6 +1615,7 @@ algorithms, knowledgebase and AI technology.
 * [Columbus Project](https://github.com/elmasy-com/columbus) - Columbus Project is an advanced subdomain discovery service with fast, powerful and easy to use API.
 * [dnsx](https://github.com/projectdiscovery/dnsx) - A fast and multi-purpose DNS toolkit from ProjectDiscovery for running DNS probes, resolving records and filtering DNS responses.
 * [Merklemap](https://www.merklemap.com/) - Discover and enumerate all subdomains associated with a website, including those not publicly advertised. Works by ingesting certificate transparency logs.
+* [Subhunt](https://github.com/ahmadouniass/Subdomains-finder-subhunt) - Multi-source subdomain enumeration tool querying crt.sh Certificate Transparency logs, HackerTarget, and RapidDNS. Features HTTP/HTTPS liveness probing with status codes, alive/dead filtering, multi-format export (TXT/JSON/CSV), and a full CLI.
 
 ## [↑](#-table-of-contents) Maritime
 


### PR DESCRIPTION
## Add Subhunt to DNS section

**Link:** https://github.com/ahmadouniass/Subdomains-finder-subhunt

Adding `Subhunt` to the **DNS** section (alphabetical position: after Merklemap).

`Subhunt` is an open-source Python CLI tool for passive subdomain enumeration. It queries three sources simultaneously — crt.sh Certificate Transparency logs, HackerTarget, and RapidDNS — merges and deduplicates results, and optionally probes each discovered subdomain for HTTP/HTTPS liveness, returning status codes (`[200]`, `[301]`, `[DEAD]`). Results export to TXT, JSON, or CSV. Fully passive recon, zero active scanning.

### Change

In the **DNS** section, after `Merklemap`:

```diff
  - [Merklemap](https://www.merklemap.com) - Discover and enumerate all subdomains associated with a website, including those not publicly advertised. Works by ingesting certificate transparency logs.
+ - [Subhunt](https://github.com/ahmadouniass/Subdomains-finder-subhunt) - Multi-source subdomain enumeration tool querying crt.sh Certificate Transparency logs, HackerTarget, and RapidDNS. Merges and deduplicates results, probes each subdomain for HTTP/HTTPS liveness with status codes, and exports to TXT/JSON/CSV.
```

### Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [awesome manifesto](https://github.com/sindresorhus/awesome/blob/master/awesome.md)
- [x] This entry is not a duplicate
- [x] Entry is inserted alphabetically (S after M)
- [x] Format follows `[Name](link) - description.`
- [x] Title is capitalized
- [x] This is an individual pull request for a single suggestion
- [x] *Disclosure: I am the author of this tool*