### PR TITLE
Add IPOK to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,7 @@ algorithms, knowledgebase and AI technology.
 * [IP Location](https://www.iplocation.net) - is used for mapping of an IP address or MAC address to the real-world geographic location of an Internet-connected computing or a mobile device.
 * [IP Location.io](https://iplocation.io) - IPLocation.io allows you to check the location of an IP for free
 * [IPFingerprints](http://www.ipfingerprints.com) - is used to find the approximate geographic location of an IP address along with some other useful information including ISP, TimeZone, Area Code, State.
+* [IPOK](https://ipok.io) - Free, no-login IP reputation lookup that aggregates up to 8 risk sources, flags residential vs datacenter, and profiles /24 C-block neighbors. Also offers a CLI and a Chrome extension.
 * [IPVoid](http://www.ipvoid.com) - IP address toolset.
 * [ISP.Tools](https://www.isp.tools) - Is a free platform offering network diagnostic tools (ping, traceroute, MTR, DNS, WHOIS, HTTP, etc.) tailored for ISPs and infrastructure professionals.
 * [Kloth](http://www.kloth.net/services)


### PR DESCRIPTION
Adds IPOK to the Domain and IP Research section.

IPOK (https://ipok.io) is a free, no-login IP reputation checker — it aggregates up to 8 risk/reputation sources and shows the per-source breakdown (rather than one opaque number), classifies an IP as residential vs datacenter, and profiles the /24 C-block neighbors. It also has a scriptable CLI (https://github.com/szp2005/ipok-cli) and a published Chrome extension.

Entry placed alphabetically in the Domain and IP Research section (between IPFingerprints and IPVoid), single line with a terminating period, following CONTRIBUTING formatting. This PR adds only the one entry.

Disclosure: I am the author/operator of ipok.io and the ipok-cli project — this is a self-promotional submission.