### PR TITLE
Add ViewIGStory to Instagram OSINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ algorithms, knowledgebase and AI technology.
 * [Osintgram](https://github.com/Datalux/Osintgram) - Osintgram offers an interactive shell to perform analysis on Instagram account of any users by its nickname.
 * [Osintgraph](https://github.com/XD-MHLOO/Osintgraph) - Tool that maps your target’s Instagram data and relationships in Neo4j for social network analysis. 
 * [Toutatis](https://github.com/megadose/toutatis) - a tool that allows you to extract information from instagrams accounts such as s, phone numbers and more
+* [ViewIGStory](https://www.view-ig-story.com) - Anonymous viewer and downloader for public Instagram stories; runs entirely in the browser without an Instagram account, leaving no trace in the target's viewer list.
 
 ### [↑](#-table-of-contents) Pinterest
 


### PR DESCRIPTION
Adds **ViewIGStory** (https://www.view-ig-story.com) to the Instagram section under Social Media Tools.

### Tool
Anonymous Instagram story viewer and downloader for public profiles. Runs entirely in the browser without an Instagram account — leaves no trace in the target's viewer list, which is the property that matters for OSINT.

### Why it fits the Instagram OSINT section
- Public-profile reconnaissance without account attribution
- No login = no risk of account flagging on the investigator side
- Complements existing entries (Instaloader for media download, Osintgram for profile analysis, etc.) by covering the live-story angle

### Style compliance
- One-line entry in the existing alphabetical format
- Inserted after Toutatis (V > T) within the Instagram subsection

Happy to revise the wording or placement.