### PR TITLE
remove Ask as it's been discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Thanks to our main contributors
 *The main search engines used by users.*
 
 * [Aol](https://search.aol.com) - The web for America.
-* [Ask](https://www.ask.com) - Ask something and get a answer.
 * [Bing](https://www.bing.com) - Microsoft´s search engine.
 * [Brave](https://search.brave.com) - a private, independent, and transparent search engine.
 * [Goodsearch](https://www.goodsearch.com) - a search engine for shopping deals online.


### PR DESCRIPTION
[Ask](https://www.ask.com/) has been discontinued.
"Ask.com officially closed on May 1, 2026"

<img width="836" height="827" alt="ask discontinuation" src="https://github.com/user-attachments/assets/94708099-6cf8-4895-acd4-eefb4dda08f3" />
