### PR TITLE
Add Fylings to Company Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ algorithms, knowledgebase and AI technology.
 * [Ezilon](http://www.ezilon.com)
 * [Factiva](https://global.factiva.com)
 * [Forbes Global 2000](http://www.forbes.com/global2000/)
+* [Fylings](https://www.fylings.com) - Free company-intelligence platform for Africa: search and verify companies across 18+ official national registries (Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM and more), with the official source and a last-verified date on every record.
 * [Glassdoor](https://www.glassdoor.com)
 * [globalEdge](http://globaledge.msu.edu)
 * [GoodFirms](https://www.goodfirms.co/)


### PR DESCRIPTION
Adds [Fylings](https://www.fylings.com) to the **Company Research** section (placed alphabetically).

Fylings is a free platform for searching and verifying companies across **18+ official African national registries** — Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM and others — with the official source and a last-verified date shown on every record. It fills a real gap in this section: coverage here is strong for the US/EU/global (OpenCorporates, Bureau van Dijk, EDGAR) but thin for African company records, a common dead end in cross-border due diligence.

_Disclosure: I'm involved with Fylings._