### PR TITLE
Add FilingFirehose to Company Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,7 @@ algorithms, knowledgebase and AI technology.
 * [European Business Register](http://www.ebr.org)
 * [Ezilon](http://www.ezilon.com)
 * [Factiva](https://global.factiva.com)
+* [FilingFirehose](https://filingfirehose.com) - Free SEC filing risk scoring on any US-listed company (LOW/MODERATE/ELEVATED/HIGH). Surfaces 8-K cyber incidents, dilution, restatement risk, and officer departures with body-text parsing that catches buried items beyond filer-reported items.
 * [Forbes Global 2000](http://www.forbes.com/global2000/)
 * [Glassdoor](https://www.glassdoor.com)
 * [globalEdge](http://globaledge.msu.edu)


### PR DESCRIPTION
Adds [FilingFirehose](https://filingfirehose.com) to the Company Research section, alphabetically between Factiva and Forbes Global 2000.

FilingFirehose is a free SEC-filing risk-scoring tool. It surfaces 8-K cyber incidents, dilution, restatement risk, and officer departures with a LOW/MODERATE/ELEVATED/HIGH grade on any US-listed company. Useful for OSINT investigators researching publicly-traded firms because it parses 8-K body text and catches buried items beyond what the filer explicitly reported.