### PR TITLE
Add AudienceCue to video tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,6 +1086,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Video Search and Other Video Tools
 
+* [AudienceCue](https://audiencecue.com/en/tools/youtube-comment-downloader) - Downloads the latest public YouTube video or Shorts comments as CSV for research workflows.
 * [Bing Videos](http://www.bing.com/?scope=video)
 * [Clarify](http://clarify.io)
 * [Clip Blast](http://www.clipblast.com)


### PR DESCRIPTION
Disclosure: I am related to AudienceCue and am submitting this addition.

This adds [AudienceCue](https://audiencecue.com/en/tools/youtube-comment-downloader) to Video Search and Other Video Tools. The linked free tool downloads the latest public YouTube video or Shorts comments as CSV, which can help OSINT researchers review publicly available audience/comment signals around a video.

Verification:
- `curl -L https://audiencecue.com/en/tools/youtube-comment-downloader` returned HTTP 200
- `git diff --check` passed