### PR TITLE
Add digga to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@ algorithms, knowledgebase and AI technology.
 * [Central Ops](http://centralops.net)
 * [Crypto Scam & Crypto Phishing URL Threat Intel Feed](https://github.com/spmedia/Crypto-Scam-and-Crypto-Phishing-Threat-Intel-Feed) - A fresh feed of crypto phishing and crypto scam websites. Automatically updated daily.
 * [Dedicated or Not](http://dedicatedornot.com)
+* [digga](https://digga.dev) - Free and open-source domain and infrastructure research toolkit combining DNS, RDAP, WHOIS, passive subdomain discovery, IP and ASN data, email authentication checks, and TLS certificate inspection. No account required.
 * [DNS History](https://completedns.com/dns-history/)
 * [DNSDumpster](https://dnsdumpster.com) - is a website that will help you discover hosts related to a specific domain.
 * [DNSStuff](http://www.dnsstuff.com)


### PR DESCRIPTION
Adds [digga](https://digga.dev/) to the Domain and IP Research section.

digga is a free and open-source domain and infrastructure research toolkit. It combines DNS lookups, RDAP with WHOIS fallback, passive subdomain discovery, IP and ASN information, email authentication checks, and TLS certificate inspection in one interface.

The entry is placed alphabetically between Dedicated or Not and DNS History. This PR adds only the single entry.

Source code: https://github.com/maaaathis/digga

_Disclosure: I am the creator and maintainer of digga, so this is a self-promotional submission._

Thanks for maintaining this list!