### PR TITLE
Add ChronoVerify to Image Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Image Analysis
 
+* [ChronoVerify](https://chronoverify.com) - API and free web tool that reads EXIF and XMP, validates C2PA Content Credentials against official trust lists, and runs classical pixel forensics, returning one typed verdict for any image.
 * [DiffChecker](https://www.diffchecker.com/image-diff/)
 * [EXIFEditor.io](https://exifeditor.io) - In-browser EXIF image metadata editor, viewer, and analysis tool.
 * [ExifLooter](https://github.com/aydinnyunus/exiflooter)


### PR DESCRIPTION
Adds ChronoVerify to Image Analysis (alphabetical, before DiffChecker).

ChronoVerify is an API and free web tool that reads EXIF and XMP, validates C2PA Content Credentials against the official trust lists, and runs classical pixel forensics, returning one typed verdict for any image, signed or not. Provenance-first; not a deepfake or AI-generation detector. Site: https://chronoverify.com