### PR TITLE
Add CrawlGraph to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,7 @@ algorithms, knowledgebase and AI technology.
 * [Browserling](https://www.browserling.com) - Browserling is an online sandbox that lets users safely test potentially malicious links across browsers and operating systems in real time.
 * [BuiltWith](http://builtwith.com) - is a website that will help you find out all the technologies used to build a particular websites.
 * [Central Ops](http://centralops.net)
+* [CrawlGraph](https://crawlgraph.com) - Maps who links to any domain using the open Common Crawl hyperlink graph. Free, no-signup referring-domain and competitor link-footprint lookups for domain research.
 * [Crypto Scam & Crypto Phishing URL Threat Intel Feed](https://github.com/spmedia/Crypto-Scam-and-Crypto-Phishing-Threat-Intel-Feed) - A fresh feed of crypto phishing and crypto scam websites. Automatically updated daily.
 * [Dedicated or Not](http://dedicatedornot.com)
 * [digga](https://digga.dev) - Free and open-source domain and infrastructure research toolkit combining DNS, RDAP, WHOIS, passive subdomain discovery, IP and ASN data, email authentication checks, and TLS certificate inspection. No account required.


### PR DESCRIPTION
Adds **CrawlGraph** to Domain and IP Research (alphabetical, alongside the other domain/backlink tools like ahrefs). It maps who links to any domain from Common Crawl's open hyperlink graph: free, no-signup referring-domain and competitor link-footprint lookups, useful for OSINT domain research. Disclosure: I am the maker; free tier needs no account.