### PR TITLE
Add Baltic Monitor to News

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ algorithms, knowledgebase and AI technology.
 * [Agence France-Presse (AFP)](http://www.afp.com)
 * [AllYouCanRead](http://www.allyoucanread.com)
 * [AP](http://hosted.ap.org)
+* [Baltic Monitor](https://baltic-monitor.com) - Daily open-source monitoring of the Baltic Sea region with a transparent 0-10 escalation-risk index, situation maps, and sourced summaries in English, Russian and Estonian; open method and machine-readable risk history.
 * [BBC News](http://www.bbc.co.uk/news)
 * [Bing News](http://www.bing.com/news)
 * [CNN](http://edition.cnn.com)


### PR DESCRIPTION
Adds Baltic Monitor to the News section (alphabetical order).

Baltic Monitor is a free, daily open-source monitoring resource for the Baltic Sea region. It publishes a transparent 0-10 escalation-risk index with documented methodology, situation maps, sourced daily summaries, a public corrections log, and labelling of sanctioned or state-controlled sources. Content is trilingual (EN/RU/ET) and the risk history is available as machine-readable JSON, so it is usable as a data source, not only as reading.

No affiliation with other entries. Description kept to one neutral line per the list style. Happy to move it to Web Monitoring if that fits better.