### PR TITLE
Add HoneyLabs to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,6 +943,7 @@ algorithms, knowledgebase and AI technology.
 * [Follow.net](http://follow.net)
 * [Fullhunt](https://fullhunt.io/) - FullHunt is an OSINT tool focused on identifying and protecting internet-exposed assets.
 * [GraphyStories](http://app.graphystories.com)
+* [HoneyLabs](https://honeylabs.net) - Free per-IP reports from a distributed honeypot network: what an IP scanned for, matched CVE exploit paths, JA4/JA4H/HASSH client fingerprints, captured payloads and VirusTotal-verified malware it delivered. Queryable anonymously on the web, over a JSON API and via an MCP server.
 * [Hudson Rock](https://www.hudsonrock.com/threat-intelligence-cybercrime-tools) - is a free cybercrime intelligence toolkit to check exposure in Infostealer malware infection.
 * [Hybrid Analysis](https://www.hybrid-analysis.com) - Online service for detailed and free analysis of suspicious files and URLs.
 * [HypeStat](https://www.hypestat.com)


### PR DESCRIPTION
Adds [HoneyLabs](https://honeylabs.net) to the Domain and IP Research section (alphabetically, before Hudson Rock).

HoneyLabs publishes free per-IP reports built from a distributed honeypot network: what an IP scanned for, matched CVE exploit paths, JA4/JA4H/HASSH client fingerprints, captured payloads, and VirusTotal-verified malware the IP delivered. Everything is queryable anonymously on the web, over a JSON API, and via an MCP server. No signup for lookups.

Single entry, matches the surrounding `* [Name](url) - description.` format. Not a duplicate.