### PR TITLE
Re-add ChronoVerify to Image Analysis (merged in #1015, lost in the #1016 merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Image Analysis
 
+* [ChronoVerify](https://chronoverify.com/) - Free image capture time and provenance checker: C2PA Content Credentials validation, EXIF/XMP consistency checks, and pixel forensics returning one verdict with a confidence score.
 * [DiffChecker](https://www.diffchecker.com/image-diff/)
 * [EXIFEditor.io](https://exifeditor.io) - In-browser EXIF image metadata editor, viewer, and analysis tool.
 * [ExifLooter](https://github.com/aydinnyunus/exiflooter)


### PR DESCRIPTION
Re-adds ChronoVerify to Image Analysis, inserted alphabetically (before DiffChecker).

This entry was accepted and merged on July 1 in #1015, but the very next merge (#1016, three minutes later, based on an older README) overwrote the line, so it never appeared in the current README. This PR simply restores it on top of the current state.

Link: https://chronoverify.com/

ChronoVerify is a free image capture time and provenance checker: it validates C2PA Content Credentials against the official C2PA/CAI trust lists, checks EXIF/XMP internal consistency, and runs classical pixel forensics, returning one plain-language verdict with a confidence score and the per-signal breakdown behind it. Images are processed in memory and never stored. It states its limits plainly: provenance validation, not a deepfake detector.

Disclosure (repeated from #1015): I built ChronoVerify, so this is a self-promotional submission, stated up front per the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
