### PR TITLE
Add Cerast Intelligence (Domain and IP Research)

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,7 @@ algorithms, knowledgebase and AI technology.
 * [Browserling](https://www.browserling.com) - Browserling is an online sandbox that lets users safely test potentially malicious links across browsers and operating systems in real time.
 * [BuiltWith](http://builtwith.com) - is a website that will help you find out all the technologies used to build a particular websites.
 * [Central Ops](http://centralops.net)
+* [Cerast Intelligence](https://search.cerast-intelligence.com/) - Searchable archive of exposed panels and misconfigurations found across domains by continuous internet-wide scanning; look up the exposure findings on record for a given domain.
 * [CrawlGraph](https://crawlgraph.com) - Maps who links to any domain using the open Common Crawl hyperlink graph. Free, no-signup referring-domain and competitor link-footprint lookups for domain research.
 * [Crypto Scam & Crypto Phishing URL Threat Intel Feed](https://github.com/spmedia/Crypto-Scam-and-Crypto-Phishing-Threat-Intel-Feed) - A fresh feed of crypto phishing and crypto scam websites. Automatically updated daily.
 * [Dedicated or Not](http://dedicatedornot.com)


### PR DESCRIPTION
Adds **Cerast Intelligence** (https://search.cerast-intelligence.com/) to the *Domain and IP Research* section (alphabetically, after Central Ops).

It is a free, searchable archive of exposed panels, misconfigurations, and other bug-class findings discovered across domains via continuous internet-wide scanning. You search by domain name and get back the exposure findings on record for each match.