### PR TITLE
Add CheckLeaked to Data Breach Search Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ algorithms, knowledgebase and AI technology.
 
 *Search engines that can be used to check if your data's been breached*
 
+* [CheckLeaked](https://checkleaked.cc/) - Check if an email, username or phone appears in a data breach, showing the sources; free searches, developer API and chat bots.
 * [CredenShow](https://credenshow.com/) - Identify your compromised credentials before others do.
 * [HIB Ransomed](https://haveibeenransom.com/) - Because people have the right to know if their data has been leaked.
 * [HEROIC.NOW](https://heroic.com/) - Has your data been leaked on the dark web? Scan your identities for FREE.


### PR DESCRIPTION
Adds **CheckLeaked** ([checkleaked.cc](https://checkleaked.cc/)) to the **Data Breach Search Engines** section.

How it helps OSINT: look up an email, username or phone number and see whether — and in which breaches — it appears, with the sources shown. Free searches, a developer REST API, and Telegram/Discord bots.

Adheres to the contribution guidelines:
- Inserted **alphabetically** (before CredenShow).
- Format: `* [CheckLeaked](https://checkleaked.cc/) - Check if an email, username or phone appears in a data breach, showing the sources; free searches, developer API and chat bots.`
- Individual PR for this single suggestion.

Disclosure: I'm affiliated with CheckLeaked.