### PR TITLE
Add Archivarix Tube Search to Video Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Video Search and Other Video Tools
 
+* [Archivarix Tube Search](https://tube.archivarix.net/) - Search engine for finding deleted, removed, and unavailable YouTube videos. 
 * [AudienceCue](https://audiencecue.com/en/tools/youtube-comment-downloader) - Downloads the latest public YouTube video or Shorts comments as CSV for research workflows.
 * [Bing Videos](http://www.bing.com/?scope=video)
 * [Clarify](http://clarify.io)


### PR DESCRIPTION
Adding Archivarix Tube Search to the Video Search and Other Video Tools section.

https://tube.archivarix.net/

It's a search engine for deleted, removed and unavailable YouTube videos, built on web archives (Wayback Machine, Common Crawl). It complements the tools already in this section: unlike Find YouTube Video it doesn't require an exact video URL — it supports channel-level discovery (all known videos of a channel, including deleted ones, via URL/@handle/legacy formats) and full-text search across titles, descriptions and subtitle transcripts; unlike Filmot it covers deleted videos and archived metadata. Subtitles of deleted videos can be downloaded as SRT. Core search is free, no registration required. There is also an open-source MCP server for AI assistants (github.com/Archivarix-com/tube-search-mcp).

Disclosure: I'm the developer of this tool.

How it helps people doing OSINT: verifying what a deleted video contained (title, description, dates, view counts, subtitles), reconstructing the upload history of terminated channels, and citing archived snapshots as evidence.