### PR TITLE
Add OSINTPRO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1668,6 +1668,7 @@ algorithms, knowledgebase and AI technology.
 * [Orbit](https://github.com/s0md3v/Orbit) - Draws relationships between crypto wallets with recursive crawling of transaction history.
 * [OSINT Framework](http://osintframework.com/) - Web based framework for OSINT.
 * [OSINT-Tool](https://www.osint-tool.com/) - A browser extension that gives you access to a suite of OSINT utilities (Dehashed, Epieos, Domaintools, Exif data, Reverse image search, etc) directly on any webpage you visit.
+* [OSINTPRO](https://github.com/haizen1312/osintpro) - Passive OSINT workspace for domain, username, repository and wallet evidence graphs with client-ready reports.
 * [OSINT.SH](https://osint.sh/) - Information Gathering Toolset.
 * [OsintStalker](https://github.com/milo2012/osintstalker) - Python script for Facebook and geolocation OSINT.
 * [Outwit](http://www.outwit.com) - Find, grab and organize all kinds of data and media from online sources.


### PR DESCRIPTION
Adds OSINTPRO to the Other Tools section.\n\nOSINTPRO is a passive OSINT workspace for domain, username, repository and wallet evidence graphs with client-ready reports.\n\nDisclosure: I am related to the OSINTPRO project.