### PR TITLE
Add VerifiedHer

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ algorithms, knowledgebase and AI technology.
 * [The National Archives (UK)](http://www.nationalarchives.gov.uk) - Search UK national archives.
 * [UniCourt](https://unicourt.com/) - Limited free searches, premium data upsell. Nationwide search of 100 million+ United States court cases.
 * [UK Phone Book](https://www.ukphonebook.com/) - Search people in a similar way as 192.com
+* [VerifiedHer](https://verifiedher.com) - Free registry of online creators and influencers answering "is she real?" — per-person pages with sourced verdicts (real / AI persona / unverified), documented official accounts, and known impersonations.
 * [VineLink](https://www.vinelink.com/#state-selection) - Inmate search and notification service for victims of crime, linked to multiple correctional facilities' booking systems in the U.S.
 * [Voter Records](https://voterrecords.com/) - Free political research tool to study more than 100 Million US voter records.
 * [White Pages (US)](http://www.whitepages.com) - People search. Limited free info, premium data upsell.


### PR DESCRIPTION
Adds [VerifiedHer](https://verifiedher.com) to People Investigations, placed alphabetically. A free, human-reviewed registry answering whether an online creator/influencer identity is real, an AI persona, or unverified — each page lists sourced evidence, the person's documented official accounts, and known impersonator patterns.

OSINT use case: verifying whether a social or paid-content account actually belongs to the person it claims to be.

Disclosure: I am one of the builders of this site. Free, no registration.