### PR TITLE
Add Sherlock-ProxyHat to Username Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ algorithms, knowledgebase and AI technology.
 * [NexFil](https://github.com/thewhiteh4t/nexfil) - checks username from almost all social network sites.
 * [Seekr](https://github.com/seekr-osint/seekr) A multi-purpose all in one toolkit for gathering and managing OSINT-Data with a neat web-interface. Can be used for note taking and username checking.
 * [Sherlock](https://github.com/sherlock-project/sherlock) - Search for a username in multiple platforms/websites.
+* [Sherlock-ProxyHat](https://github.com/ProxyHatCom/sherlock-proxyhat) - CLI wrapper that runs Sherlock username searches through rotating residential proxies to reduce IP blocks and rate-limiting during large sweeps; supports geo-targeting. Built on the commercial ProxyHat service.
 * [SherlockEye](https://sherlockeye.io/) - Search for publicly available information connected to a username, uncovering associated profiles and activities across the web.
 * [Trace](https://trace.manus.space) - Real-time OSINT platform to search usernames, emails, phone numbers, and full names across 600+ platforms with breach detection and AI risk scoring.
 * [Snoop](https://github.com/snooppr/snoop/blob/master/README.en.md) - Search for a nickname on the web (OSINT world)


### PR DESCRIPTION
Adds Sherlock-ProxyHat to the Username Check section (alphabetically, right after the existing Sherlock entry).

What it is: an open-source (MIT) CLI launcher that runs Sherlock's username searches through rotating residential proxies, so large multi-site sweeps hit fewer IP blocks and rate limits, with optional geo-targeting. Repo: https://github.com/ProxyHatCom/sherlock-proxyhat (also on PyPI as `sherlock-proxyhat`).

Disclosure: this is a self-promotional submission — I work on ProxyHat, the proxy service this tool uses. Flagging up front per the contribution guidelines. Single suggestion, inserted alphabetically, follows the `[Name](link) - description.` format.