### PR TITLE
Add IntelCue Subdomain Finder to DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1629,6 +1629,7 @@ algorithms, knowledgebase and AI technology.
 * [Amass](https://github.com/owasp-amass/amass) - The amass tool searches Internet data sources, performs brute force subdomain enumeration, searches web archives, and uses machine learning to generate additional subdomain name guesses. DNS name resolution is performed across many public servers so the authoritative server will see the traffic coming from different locations. Written in Go.
 * [Columbus Project](https://github.com/elmasy-com/columbus) - Columbus Project is an advanced subdomain discovery service with fast, powerful and easy to use API.
 * [dnsx](https://github.com/projectdiscovery/dnsx) - A fast and multi-purpose DNS toolkit from ProjectDiscovery for running DNS probes, resolving records and filtering DNS responses.
+* [IntelCue Subdomain Finder](https://www.intelcue.ai/tools/subdomain-finder) - Free subdomain finder powered by Certificate Transparency logs, no signup required.
 * [Merklemap](https://www.merklemap.com/) - Discover and enumerate all subdomains associated with a website, including those not publicly advertised. Works by ingesting certificate transparency logs.
 * [Subhunt](https://github.com/ahmadouniass/Subdomains-finder-subhunt) - Multi-source subdomain enumeration tool querying crt.sh Certificate Transparency logs, HackerTarget, and RapidDNS. Features HTTP/HTTPS liveness probing with status codes, alive/dead filtering, multi-format export (TXT/JSON/CSV), and a full CLI.
 


### PR DESCRIPTION
Adds IntelCue Subdomain Finder (https://www.intelcue.ai/tools/subdomain-finder) to the DNS section, alphabetically between dnsx and Merklemap.

**Disclosure:** I'm affiliated with IntelCue. It's a free, no-signup subdomain finder built on Certificate Transparency logs, similar in scope to Merklemap and Subhunt already listed in this section.