### PR TITLE
[codex] Add DeepFakeCheck to Image Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,7 @@ algorithms, knowledgebase and AI technology.
 ## [↑](#-table-of-contents) Image Analysis
 
 * [ChronoVerify](https://chronoverify.com) - API and free web tool that reads EXIF and XMP, validates C2PA Content Credentials against official trust lists, and runs classical pixel forensics, returning one typed verdict for any image.
+* [DeepFakeCheck](https://deepfakecheck.io/?utm_source=awesome_osint&utm_medium=referral&utm_campaign=directory_launch_2026q3) - Free web tool that combines C2PA provenance, metadata clues, and AI analysis to review images and other media for signs of manipulation, returning evidence with explicit uncertainty rather than proof.
 * [DiffChecker](https://www.diffchecker.com/image-diff/)
 * [EXIFEditor.io](https://exifeditor.io) - In-browser EXIF image metadata editor, viewer, and analysis tool.
 * [ExifLooter](https://github.com/aydinnyunus/exiflooter)


### PR DESCRIPTION
Disclosure: I am connected with DeepFakeCheck.

This PR adds [DeepFakeCheck](https://deepfakecheck.io/?utm_source=awesome_osint&utm_medium=referral&utm_campaign=directory_launch_2026q3) as one entry under Image Analysis.

DeepFakeCheck can support an OSINT first-pass review of suspicious images and other media by combining C2PA provenance when available, metadata clues, and AI-based analysis. It reports evidence with explicit uncertainty rather than treating the result as proof.

Important limitations: AI detection can produce false positives and false negatives; C2PA and useful metadata may be absent; metadata can be edited; and results should be combined with independent verification.

Checks performed:

- Confirmed there is no existing DeepFakeCheck entry or open submission.
- Kept the entry alphabetically ordered.
- Limited the change to one list item.
- Confirmed the destination returns HTTP 200.
- Ran git diff --check.