### PR TITLE
Add DomainIntel.app to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,7 @@ algorithms, knowledgebase and AI technology.
 * [Domain Crawler](https://www.domaincrawler.com)
 * [Domain Dossier](https://centralops.net/co/DomainDossier.aspx)
 * [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) - Aggregate DNS, WHOIS/RDAP, SSL, subdomains (CT logs + DNS bruteforce), and SPF/DMARC posture in one call. Free tier; MIT.
+* [DomainIntel.app](https://domainintel.app) - WHOIS, DNS records, SSL/TLS inspection, HTTP security headers, blacklist reputation, and subdomain discovery for any domain, with an overall A–F security score. Free, no signup.
 * [DomainRecon](https://kriztalz.sh/domain-recon/) - Retrieve DNS records, subdomains, SSL certificates and WHOIS / RDAP data for a given website.
 * [Domain Tools](https://whois.domaintools.com) - Whois lookup and domain/ip historical data.
 * [Easy whois](https://www.easywhois.com)


### PR DESCRIPTION
Adds **DomainIntel.app** to the Domain and IP Research section (placed alphabetically among the Domain* tools).

It provides WHOIS, DNS records, SSL/TLS inspection, HTTP security headers, blacklist reputation, and subdomain discovery for any domain, with an overall A–F security score. Free to use, no signup required — consistent with the other free lookup tools in this section.

Disclosure: I'm the maintainer of this tool.