### PR TITLE
Add Netruneer Email DNS Snapshot to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,7 @@ algorithms, knowledgebase and AI technology.
 * [MaxMind](https://www.maxmind.com)
 * [MetaDefender](https://metadefender.com) - Threat analysis service for URLs, files, certificates, domains, and suspicious hashes.
 * [Netcraft Site Report](https://toolbar.netcraft.com/site_report?url=undefined#last_reboot) - is an online database that will provide you a report with detail information about a particular website and the history associated with it.
+* [Netruneer Email DNS Snapshot](https://alexispomares.github.io/netruneer-site/check/)  - Free, no-signup SPF, DMARC, and MX snapshot using bounded public DNS queries.
 * [OpenLinkProfiler](https://www.openlinkprofiler.org/)
 * [PageGlimpse](https://www.pageglimpse.com)
 * [Pentest-Tools.com](https://pentest-tools.com/information-gathering/google-hacking) - uses advanced search operators (Google Dorks) to find juicy information about target websites.


### PR DESCRIPTION
## What changed

Adds [Netruneer Email DNS Snapshot](https://alexispomares.github.io/netruneer-site/check/) to **Domain and IP Research**.

## Why it helps OSINT users

The free, no-signup page makes exactly three bounded public-DNS queries for SPF, DMARC, and MX. It does not contact discovered mail hosts, request credentials, store inputs, or claim a security or deliverability verdict.

## Affiliation disclosure

I own and maintain Netruneer and am submitting this listing for my own tool.

## Checks

- One suggestion only
- Alphabetical placement after Netcraft
- Required list-entry format and trailing punctuation
- Live link checked before submission
