### PR TITLE
Add THINKPOL to Reddit tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ algorithms, knowledgebase and AI technology.
 * [Pushshift API](https://pushshift.io/) - A powerful API that provides access to historical Reddit data, including posts, comments, and metadata for analysis and research—more information [here](https://www.reddit.com/r/pushshift/).
 * [Pullpush](https://pullpush.io/) - PullPush is a service for the indexing and retrieval of content that Reddit users have submitted to Reddit. Helpful for finding deleted/removed posts & comments.
 * [REDARCS](https://the-eye.eu/redarcs/) - Reddit archives 2005-2023.
+* [THINKPOL](https://think-pol.com/tools) - Free Reddit OSINT tools backed by a 30-billion-post archive including deleted and removed content: user lookup, deleted-post viewer, subreddit intelligence, and archive search.
 * [Reddit Archive](http://www.redditarchive.com) - Historical archives of reddit posts.
 * [Reddit Suite](https://chrome.google.com/webstore/detail/reddit-enhancement-suite/kbmfpngjjgdllneeigpgjifpgocmfgmb) - Enhances your reddit experience.
 * [Reddit User Analyser](https://atomiks.github.io/reddit-user-analyser/) - reddit user account analyzer.


### PR DESCRIPTION
Adds THINKPOL under Reddit. Disclosure: I work for THINKPOL. It offers free Reddit OSINT tools (user lookup, deleted/removed-post viewer, subreddit intelligence, archive search) backed by a large historical archive, which fills the gap left by Pushshift's shutdown - relevant alongside the existing Pullpush/REDARCS/Arctic Shift entries. One tool per the contributing guide.