### PR TITLE
Add Nutilz WHOIS Lookup to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,7 @@ algorithms, knowledgebase and AI technology.
 * [MaxMind](https://www.maxmind.com)
 * [MetaDefender](https://metadefender.com) - Threat analysis service for URLs, files, certificates, domains, and suspicious hashes.
 * [Netcraft Site Report](https://toolbar.netcraft.com/site_report?url=undefined#last_reboot) - is an online database that will provide you a report with detail information about a particular website and the history associated with it.
+* [Nutilz WHOIS Lookup](https://nutilz.com/whois-lookup) - Free WHOIS lookup tool. Query the raw WHOIS record for any domain — registrar, creation/expiry dates, nameservers and status. Server-side lookup, no sign-up required.
 * [OpenLinkProfiler](https://www.openlinkprofiler.org/)
 * [PageGlimpse](https://www.pageglimpse.com)
 * [Pentest-Tools.com](https://pentest-tools.com/information-gathering/google-hacking) - uses advanced search operators (Google Dorks) to find juicy information about target websites.


### PR DESCRIPTION
Adds [Nutilz WHOIS Lookup](https://nutilz.com/whois-lookup), a free server-side WHOIS lookup tool — no sign-up required. Returns registrar, creation/expiry dates, nameservers and status for any domain.

Inserted alphabetically under Domain and IP Research, between Netcraft Site Report and OpenLinkProfiler, per CONTRIBUTING.md.

Disclosure: I am affiliated with nutilz.com.