### PR TITLE
Add Competitive Intelligence Prompt Scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,7 @@ algorithms, knowledgebase and AI technology.
 * [GuideStar](https://www.guidestar.org)
 * [Hoovers](https://www.hoovers.com)
 * [Inc. 5000](https://www.inc.com/inc5000)
+* [IntelCue Competitive Intelligence Prompt Scorer](https://www.intelcue.ai/tools/competitive-intelligence-prompt-scorer) - Free tool that scores a competitive intelligence AI prompt from 0 to 100 across 9 categories and generates an optimized version.
 * [Judyrecords](https://www.judyrecords.com/) - Free. Nationwide search of 400 million+ United States court cases.
 * [Knowledge guide to international company registration](https://www.icaew.com/en/library/subject-gateways/business-management/company-administration/knowledge-guide-international-company-registration)
 * [Linkedin](https://www.linkedin.com) - Commonly used social-media platform with a focus on professional profiles and recruitment. Spans a wide variety of industries. Very useful for gathering information on what specific individuals are active within an entity.


### PR DESCRIPTION
Adds IntelCue Competitive Intelligence Prompt Scorer to Company Research.

Disclosure: this is our own tool (IntelCue).

It is a free tool that scores a competitive intelligence AI prompt from 0 to 100 across 9 categories and generates an optimized version, useful when researching a specific company or set of competitors. It runs entirely in the browser: no signup, and nothing typed into it is sent anywhere.