### PR TITLE
Add Registrly to Company Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ algorithms, knowledgebase and AI technology.
 * [Orbis directory](https://orbisdirectory.bvdinfo.com/version-20161014/OrbisDirectory/Companies)
 * [Overseas Company Registers](https://www.gov.uk/government/publications/overseas-registries/overseas-registries)
 * [Plunkett Research](https://www.plunkettresearchonline.com)
+* [Registrly](https://registrly.com) - Free company and legal-entity verification: cross-references UK Companies House and the Global LEI (GLEIF) registries, with the official source, registration status, and registry-context stats on every record.
 * [Scoot](https://www.scoot.co.uk)
 * [Section 16 Deadline Calculator](https://github.com/Turner-Levey/section-16-deadline-calculator)  - Open-source browser-only worksheet for common SEC Forms 3, 4, and 5 ownership-reporting deadline planning, with memo and CSV copy outputs.
 * [SEMrush](https://www.semrush.com)


### PR DESCRIPTION
Adds Registrly (https://registrly.com), a free tool that cross-references UK Companies House and GLEIF's Global LEI registry to verify company/legal-entity registration status, with comparative registry-context stats not shown on either source individually.

Disclosure: I built and operate this site.