### PR TITLE
Add openSquat to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,7 @@ algorithms, knowledgebase and AI technology.
 * [MetaDefender](https://metadefender.com) - Threat analysis service for URLs, files, certificates, domains, and suspicious hashes.
 * [Netcraft Site Report](https://toolbar.netcraft.com/site_report?url=undefined#last_reboot) - is an online database that will provide you a report with detail information about a particular website and the history associated with it.
 * [OpenLinkProfiler](https://www.openlinkprofiler.org/)
+* [openSquat](https://github.com/atenreiro/opensquat) - Open source tool that searches newly registered domain feeds to find typosquatting, IDN homograph, doppelganger and bitsquatting domains impersonating a given brand or keyword.
 * [PageGlimpse](https://www.pageglimpse.com)
 * [Pentest-Tools.com](https://pentest-tools.com/information-gathering/google-hacking) - uses advanced search operators (Google Dorks) to find juicy information about target websites.
 * [PhishStats](https://phishstats.info/)


### PR DESCRIPTION
Adds [openSquat](https://github.com/atenreiro/opensquat) to the Domain and IP Research section.

openSquat is an open source Python tool that scans daily newly registered domain (NRD) feeds to find domains impersonating a brand or keyword — typosquatting, IDN homograph attacks, doppelganger domains and bitsquatting — using Levenshtein distance, with optional enrichment from VirusTotal, Quad9 and Certificate Transparency logs.

**How this helps OSINT:** it surfaces lookalike and phishing infrastructure targeting an organisation as it is registered, which is useful for brand monitoring, phishing investigation and threat hunting. It complements [Squatm3gator](https://github.com/david3107/squatm3gator), already listed, which generates candidate permutations — openSquat instead detects domains actually registered in the wild.

Inserted alphabetically and follows the existing entry format.

Disclosure: I'm the author of the project.