### PR TITLE
Add osint-recon — passive OSINT recon framework in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,6 +975,7 @@ algorithms, knowledgebase and AI technology.
 * [Netcraft Site Report](https://toolbar.netcraft.com/site_report?url=undefined#last_reboot) - is an online database that will provide you a report with detail information about a particular website and the history associated with it.
 * [OpenLinkProfiler](https://www.openlinkprofiler.org/)
 * [openSquat](https://github.com/atenreiro/opensquat) - Open source tool that searches newly registered domain feeds to find typosquatting, IDN homograph, doppelganger and bitsquatting domains impersonating a given brand or keyword.
+* [osint-recon](https://github.com/JMarchiori13/osint-recon) - Passive OSINT reconnaissance framework in Rust: subdomains, DNS, ASN, certificate transparency history, GitHub dorking, tech fingerprinting, emails and document metadata for authorized red team engagements.
 * [PageGlimpse](https://www.pageglimpse.com)
 * [Pentest-Tools.com](https://pentest-tools.com/information-gathering/google-hacking) - uses advanced search operators (Google Dorks) to find juicy information about target websites.
 * [PhishStats](https://phishstats.info/)


### PR DESCRIPTION
Adds [osint-recon](https://github.com/JMarchiori13/osint-recon) to the **Domain and IP Research** section (one line, alphabetical position, matching the list's format).

**osint-recon** is a passive OSINT reconnaissance framework written in Rust for authorized red team engagements:

- Passive techniques only — certificate transparency (crt.sh), DNS-over-HTTPS, Team Cymru ASN data, keyless public aggregators; no scanning, no brute force
- Modules: subdomains, DNS records, ASN/netblocks, CT history, GitHub dorking, tech fingerprinting, email harvesting, PDF metadata
- JSON/CSV/JSONL export, stdin batch targets, prebuilt binaries for Windows/Linux/macOS
- Actively maintained, MIT licensed, CI-tested

Thanks for maintaining this list!