### PR TITLE
Add DorkCraft to Google Dorks Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ algorithms, knowledgebase and AI technology.
 *Google Dorks Tools*
 
 * [AtDork](https://github.com/amnottdevv/atdork) - Professional OSINT dorking tool featuring adaptive delay, circuit breaker, and automatic backend fallback to avoid IP bans and rate limits.
+* [DorkCraft](https://github.com/juandresrodca/DorkCraft) - Google dork generator that builds advanced search queries for OSINT and reconnaissance.
 * [DorkGenius](https://dorkgenius.com/) - DorkGenius is the ultimate tool for generating custom search queries for Google, Bing, and DuckDuckGo. - Our cutting-edge app uses the power of AI to help you create advanced search queries that can find exactly what you're looking for on the web.
 * [DorkGPT](https://www.dorkgpt.com/) - Generate Google Dorks with AI.
 * [Google Hacking Database (GHDB)](https://www.exploit-db.com/google-hacking-database) - The GHDB is an index of search queries (we call them dorks) used to find publicly available information, intended for pentesters and security researchers.


### PR DESCRIPTION
Adds **DorkCraft** to the *Google Dorks Tools* section (placed alphabetically after AtDork).

DorkCraft is an open-source Google dork generator that builds advanced search queries for OSINT and reconnaissance (Astro + FastAPI).

- Repo: https://github.com/juandresrodca/DorkCraft

_Disclosure: this is my own project — happy to adjust the wording or placement if needed._