### PR TITLE
 Add Onbekendnummer.nl to Phone Number Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ algorithms, knowledgebase and AI technology.
 * [FreeCarrierLookup](https://freecarrierlookup.com/) - enter a phone number and we'll return the carrier name and whether the number is wireless or landline. We also return the email-to-SMS and email-to-MMS gateway addresses for USA and Canadian* phone numbers.
 * [Infobel](https://www.infobel.com/) - Search 164+ million records across 73 countries for companies and individuals. Find places, local service providers, their contact details, reviews, opening hours and more.
 * [InMobPrefix](https://github.com/hstsethi/in-mob-prefix) - Dataset, charts, models about mobile phone numbers prefixes in India along with their respective state, operator.
+* [Onbekendnummer.nl](https://onbekendnummer.nl/) - Dutch phone number lookup built on the official open-data number registry of telecom regulator ACM: shows the assigned range, holder company with KvK (chamber of commerce) ID and blocked or cooling-down status for any Dutch number, combined with community spam reports and area/country code reference.
 * [Phone Validator](https://www.phonevalidator.com/index.aspx) - Pretty accurate phone lookup service, particularly good against Google Voice numbers.
 * [PhoneInfoga](https://github.com/sundowndev/PhoneInfoga) - Advanced information gathering & OSINT framework for phone numbers.
 * [Reverse Phone Check](https://www.reversephonecheck.com) - Look up names, addresses, phone numbers, or emails and anonymously discover information about yourself, family, friends, or old schoolmates. Powered by infotracer.com


### PR DESCRIPTION
Adds Onbekendnummer.nl to the Phone Number Research section (alphabetical order, one link).

[](https://onbekendnummer.nl)

Disclosure: I am the creator and operator of this site.

OSINT value: for any Dutch phone number it shows the officially assigned number range and the holding company with its KvK (Dutch chamber of commerce) ID, straight from the open-data number registry of the Dutch telecom regulator ACM, combined with community spam reports and area/country code reference pages. Free, no account required.