### PR TITLE
Add JPEG Audit under Image Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,6 +1095,7 @@ algorithms, knowledgebase and AI technology.
 * [ImpulseAdventure](https://www.impulseadventure.com/photo/jpeg-snoop.html)
 * [Jeffreys Image Metadata Viewer](https://exif.regex.info/)
 * [JIMPL](https://jimpl.com/) - Online EXIF data viewer
+* [JPEG Audit](https://jpegaudit.com) - Free online JPEG forensics: EXIF/IPTC/XMP and GPS, automated tamper checks with a severity-rated verdict, JPEG structure and quantization tables, perceptual hash, and a Street View comparison using the EXIF camera bearing.
 * [JPEGsnoop](https://sourceforge.net/projects/jpegsnoop)
 * [Metadata Viewer](https://kriztalz.sh/metadata-viewer/) - Online EXIF data viewer.
 * [ProfileImageIntel](https://profileimageintel.com/) - Social media and WhatsApp profile image tool to find when a profile image was uploaded.


### PR DESCRIPTION
Adds JPEG Audit to Image Analysis.

Disclosure: I built it.

It reads EXIF/IPTC/XMP and GPS, runs automated consistency checks and returns a severity-rated verdict — timestamp contradictions, editing-software traces, thumbnail-vs-image mismatch, trailing data — and shows the JPEG marker structure, quantization tables and a perceptual hash.

The part most relevant to OSINT work: when a photo carries a GPS bearing (GPSImgDirection), it puts the photo side by side with a Street View panorama at those coordinates turned to the same heading — the location check people otherwise do by hand.

Free, no account, no limits.