### PR TITLE
Add UAV Radar to Geospatial Research and Mapping Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,6 +1239,7 @@ algorithms, knowledgebase and AI technology.
 * [StoryMaps](https://storymaps.arcgis.com/en)
 * [SunCalc](https://www.suncalc.org/)
 * [Tableau](https://www.tableausoftware.com)
+* [UAV Radar](https://uavradar.live/) - Live map of air-raid alerts and drone-attack reports across Ukraine and Russia at district granularity, with 30-day per-region statistics and an open JSON API.
 * [USGS (EarthExplorer)](https://earthexplorer.usgs.gov/)
 * [ViaMichelin](https://www.viamichelin.com)
 * [View in Google Earth](https://www.mgmaps.com/kml/#view)


### PR DESCRIPTION
Adds [UAV Radar](https://uavradar.live/) to *Geospatial Research and Mapping Tools*.

It is a live map of air-raid alerts and drone-attack reports across Ukraine and Russia, rendered at district (raion) granularity rather than country or oblast level, with a 24-hour replay and 30 days of per-region statistics — how often alerts happen and how long they last — which I have not found published elsewhere. That data is open JSON at https://uavradar.live/api/stats.

Reports are aggregated from public Telegram channels, named on the site: @air_alert_ua (relaying Ukraine's official air-raid alerts) and @radarrussiia (an informal Russian aggregator). Limitations are stated openly in the About section: two sources, relayed unverified, 30 days of history.

Free, no registration, no ads, and no trackers or analytics of any kind.

Disclosure: I am the author of this site.