### PR TITLE
Add UAV Radar to Data and Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,6 +1371,7 @@ algorithms, knowledgebase and AI technology.
 * [The Data and Story Library](https://lib.stat.cmu.edu/DASL)
 * [Trading Economics](https://www.tradingeconomics.com)
 * [Transparency.org Corruption Perception Index](https://www.transparency.org/cpi2015)
+* [UAV Radar](https://uavradar.live/) - Air-raid alert and drone-attack statistics for Ukraine and Russia at district level: per region, how many alert episodes occurred, how many ended, and how long they typically last, over a rolling 30 days. Free JSON API, no registration, CC BY 4.0.
 * [UN COMTRADE Database](https://comtrade.un.org)
 * [UN Data](https://data.un.org)
 * [UNCTAD Country Fact Sheets](https://unctad.org/en/Pages/DIAE/World%20Investment%20Report/Country-Fact-Sheets.aspx)


### PR DESCRIPTION
Adds [UAV Radar](https://uavradar.live/) to *Data and Statistics*.

**Disclosure: I am the author of this site.** I also opened #1078, which proposed the same site for *Geospatial Research and Mapping Tools* and was closed. I think that section was the wrong fit and this one is the right one, so this is a different proposal rather than a retry — if you disagree, closing it is a fine answer and I won't open a third.

**What the data is.** A rolling 30 days of air-raid alert statistics for Ukraine and Russia, at district (raion) granularity rather than country or oblast level. For each of ~79 regions: how many alert episodes occurred, how many have ended, and the median and mean duration. Published as JSON at https://uavradar.live/api/stats — no key, no registration, CORS open, ~1.6 KB.

**Why it may be useful for OSINT.** Alert *feeds* are easy to find; alert *statistics* at district level are not. The endpoint answers "is this unusual for this district?" — which is the question that turns a single report into a finding. Methodology and limitations are stated on the site: two named public Telegram sources, relayed unverified, 30 days of history.

**Licence.** [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/), stated on the [About page](https://uavradar.live/about) in all three interface languages. Free to use and republish with attribution.

Free, no registration, no ads, and no trackers or analytics of any kind.
