### PR TITLE
Add ScanMalware to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ algorithms, knowledgebase and AI technology.
 * [Remote DNS Lookup](https://remote.12dt.com)
 * [Robtex](https://www.robtex.com) - is an IP address and domain name based researching websites that offers multiple services such as Reverse DNS Lookup, Whois, and AS Macros.
 * [SameID](https://sameid.net)
+* [ScanMalware](https://scanmalware.com) - Free URL scanner that renders a page in a sandboxed browser and reports phishing and malware verdicts, network requests, technologies, TLS/JARM fingerprints and screenshots, with a public feed of recent scans searchable by domain, IP, ASN or favicon hash.
 * [SecurityTrails](https://securitytrails.com/dns-trails) - API to search current and historical DNS records, current and historical WHOIS, technologies used by sites and whois search for phone, email, address, IPs etc.
 * [SubDomainRadar.io](https://subdomainradar.io) - Fast subdomain finder with multiple search modes and the most extensive data sources, offering real-time notifications.
 * [SEMrush](https://www.semrush.com)


### PR DESCRIPTION
Disclosure per the contribution guidelines: I work on this — ScanMalware (https://scanmalware.com) is run by Triop AB in Sweden.

**How it helps people doing OSINT.** Submit a URL and it renders the page in a sandboxed browser, recording network requests, forms, detected technologies, TLS/JARM fingerprints and a screenshot. Every scan is then searchable, which is the part that matters for investigation: from one phishing page you can pivot to related infrastructure by favicon hash, JARM, ASN, screenshot hash or fuzzy hash. The feed of recent public scans is browsable without an account, and the REST API allows 600 requests/minute anonymously (https://scanmalware.com/api-docs).

Closest neighbours already in this section are urlscan, urlQuery and Virus Total, so it sits alongside those rather than duplicating any of them.

Checked against the guidelines:

- Inserted alphabetically, between SameID and SecurityTrails
- Single entry, single PR
- `[Name](link) - additional information.` format
- No trailing whitespace (`git diff --check` clean)
- Searched the README first; ScanMalware is not currently listed anywhere in it