### PR TITLE
Add CC.LA — free WHOIS/DNS/domain research toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,6 +928,7 @@ algorithms, knowledgebase and AI technology.
 * [BuiltWith](https://builtwith.com) - is a website that will help you find out all the technologies used to build a particular websites.
 * [Central Ops](https://centralops.net)
 * [Cerast Intelligence](https://search.cerast-intelligence.com/) - Searchable archive of exposed panels and misconfigurations found across domains by continuous internet-wide scanning; look up the exposure findings on record for a given domain.
+* [CC.LA](https://cc.la) - Free WHOIS, RDAP, DNS, IP WHOIS, name server history, SSL certificate lookup, and network diagnostic tools (ping/traceroute/MTR). Also provides expiring domain calendars, TLD library, domain monitoring, and domain availability checker. No sign-up required.
 * [CrawlGraph](https://crawlgraph.com) - Maps who links to any domain using the open Common Crawl hyperlink graph. Free, no-signup referring-domain and competitor link-footprint lookups for domain research.
 * [Crypto Scam & Crypto Phishing URL Threat Intel Feed](https://github.com/spmedia/Crypto-Scam-and-Crypto-Phishing-Threat-Intel-Feed) - A fresh feed of crypto phishing and crypto scam websites. Automatically updated daily.
 * [Dedicated or Not](https://dedicatedornot.com)


### PR DESCRIPTION
## Description

Add [CC.LA](https://cc.la) to the Domain and IP Research section.

CC.LA is a free, no-sign-up domain research platform offering:
- **WHOIS & RDAP lookup** with freshness annotations and history snapshots
- **DNS records** inspection (SOA/NS/A/MX/CNAME/TXT + all records)
- **IP WHOIS** with reverse lookup
- **Name server history** and domain availability checker
- **SSL/TLS certificate** lookup
- **Network diagnostics**: ping, traceroute, MTR
- **Expiring/deleting domain calendars** and TLD library
- **Domain monitoring** (uptime + DNS change detection)

The platform is actively maintained (Next.js 16, deployed on Vercel) and adheres to the free/no-signup ethos of the tools already listed in this section.