### PR TITLE
Add RedditAPIs to Reddit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ algorithms, knowledgebase and AI technology.
 * [Reddit Suite](https://chrome.google.com/webstore/detail/reddit-enhancement-suite/kbmfpngjjgdllneeigpgjifpgocmfgmb) - Enhances your reddit experience.
 * [Reddit User Analyser](https://atomiks.github.io/reddit-user-analyser/) - reddit user account analyzer.
 * [RedditMetis](https://redditmetis.com/) - RedditMetis is a Reddit user analysis tool to see the summary and statistics for a Reddit account, including top posts and user activity etc.
+* [RedditAPIs](https://www.redditapis.com) - Reddit data API: subreddit listings, post/comment/community/user search, comment trees, top posts.
 * [Subreddits](https://subreddits.org) - Discover new subreddits.
 * [Reddit Comment Search](https://redditcommentsearch.com/) - Analyze a reddit users by comment history.
 * [Universal Scammer List](https://universalscammerlist.com/) - This acts as the website-portion for the subreddit /r/universalscammerlist. That subreddit, in conjuction with this website and a reddit bot, manages a list of malicious reddit accounts and minimizes the damage they can deal. This list is referred to as the "USL" for short.


### PR DESCRIPTION
Add RedditAPIs to the Reddit section.

RedditAPIs is a Reddit data API: subreddit listings, post/comment/community/user search, comment trees, top posts. Checked the existing Reddit section for overlap: Pushshift API and Pullpush are the closest comparables (Reddit data-access tools), this is a distinct product, not a duplicate.

- Site: https://www.redditapis.com
- Docs: https://docs.redditapis.com

Grouped with the other Reddit-prefixed entries. Voice matches existing entries (factual, single-sentence, no marketing language).
