### PR TITLE
Add Orbit Sentinel to Company Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,7 @@ algorithms, knowledgebase and AI technology.
 * [OpenCorporates](https://opencorporates.com) - Global search of registered corporate entities and their associated individual officers or investors.
 * [OpenOwnership Register](https://register.openownership.org/)
 * [Orbis directory](https://orbisdirectory.bvdinfo.com/version-20161014/OrbisDirectory/Companies)
+* [Orbit Sentinel](https://www.viventine.com/orbit-sentinel/) - Searchable database of 950K+ space regulatory filings (FCC, ITU, UNOOSA, FAA-AST) with entity dossiers linking corporate filings, SEC records, and sanctions screening.
 * [Overseas Company Registers](https://www.gov.uk/government/publications/overseas-registries/overseas-registries)
 * [Plunkett Research](https://www.plunkettresearchonline.com)
 * [Scoot](https://www.scoot.co.uk)


### PR DESCRIPTION
Adds Orbit Sentinel to Company Research — a searchable database of 950K+ space regulatory filings (satellite license applications, grants, spectrum holdings, launch licenses) from the FCC, ITU, UNOOSA, and FAA-AST. Its entity dossiers link a company's regulatory filings with SEC records and sanctions screening, making it useful for due diligence and investigations involving space/satellite companies — a niche not covered by existing entries like OpenCorporates or EDGAR. Placed alphabetically after Orbis directory.