### PR TITLE
Add MetaClean to privacy tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1600,6 +1600,7 @@ algorithms, knowledgebase and AI technology.
 * [Mailbox](https://mailbox.org)
 * [Mailvelope](https://www.mailvelope.com)
 * [Master Password](https://masterpasswordapp.com)
+* [MetaClean](https://github.com/Moresyl/metaclean) - Cross-platform desktop app for removing sensitive metadata from files locally before sharing them during OSINT investigations.
 * [Nixory](https://nixory.sourceforge.net)
 * [NoScript](https://noscript.net)
 * [Open DNS](https://www.opendns.com/home-internet-security)


### PR DESCRIPTION
Disclosure: I am the author and maintainer of [MetaClean](https://github.com/Moresyl/metaclean).

This adds one alphabetized entry to **Privacy and Encryption Tools**. MetaClean is an open-source cross-platform desktop app that removes metadata locally from images, PDFs, Office documents, and text files. It helps OSINT practitioners avoid unintentionally exposing investigator, device, author, or location metadata when sharing collected files, screenshots, evidence, or reports.

The entry follows the list's existing format and this PR changes only that single item.