### PR TITLE
Add DataInt Databook to Data and Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1332,6 +1332,7 @@ algorithms, knowledgebase and AI technology.
 * [CEPII](https://www.cepii.fr/CEPII/en/welcome.asp)
 * [CIA World Factbook](https://www.cia.gov/the-world-factbook/)
 * [Crime Brasil](https://crimebrasil.com.br) - Open-data platform consolidating Brazilian crime statistics (RS neighborhood-level, MG/RJ municipality, national PRF/DATASUS). Free API, CC BY 4.0.
+* [DataInt Databook](https://databook.dataint.net) - Country reference pages for 250 countries (population, economy, geography, infrastructure, defence, governance) compiled from World Bank, UN, UNESCO and World Factbook, with each figure attributed to its source. 25 languages. Web reference only, no API or bulk download.
 * [Data.gov.uk](https://data.gov.uk)
 * [DBPedia](https://wiki.dbpedia.org)
 * [European Union Open Data Portal](https://open-data.europa.eu/en/data)


### PR DESCRIPTION
Adds one entry to **Data and Statistics**, inserted alphabetically between Crime Brasil and Data.gov.uk.

**Disclosure up front, as CONTRIBUTING asks:** I maintain this site. This is a self-submission.

**How it helps someone doing OSINT:** country-level reference figures — population, economy, geography, infrastructure, defence, governance — for 250 countries in one place, with the publishing institution named next to each figure so a researcher can verify against the original source rather than taking our word for it. It sits in the same category as Index Mundi and the CIA World Factbook, both already on this list.

**Limits, stated in the entry itself so it isn't misleading:**
- Web reference only. No API, no bulk download, no CSV export.
- No original data collection — everything is compiled from World Bank, UN agencies, UNESCO and the World Factbook.
- The site carries advertising.

Published in 25 languages, which occasionally matters when working on a country whose local-language sources you can't read.

Entirely reasonable to close this if a read-only reference with ads isn't what the list is for.
