### PR TITLE
Add WhiteIntel to Company Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ algorithms, knowledgebase and AI technology.
 * [Tracxn](https://tracxn.com) - Search information about a company such as aquisitions, investors, people, research, etc
 * [UniCourt](https://unicourt.com/) - Limited free searches, premium data upsell. Nationwide search of 100 million+ United States court cases.
 * [Vault](https://www.vault.com) - Well-known ranking of largest United States Corporations.
+* [WhiteIntel](https://whiteintel.dev) - Free corporate and offshore ownership graph: trace a company to its beneficial owners across 31 public registries (Companies House, GLEIF, ICIJ Offshore Leaks, OpenSanctions, SEC EDGAR), with sanctions screening and fully cited dossiers. Queryable by AI agents over MCP.
 * [Xing](https://www.xing.com)
 * [YouControl](https://youcontrol.com.ua/en/)
 


### PR DESCRIPTION
Adds **WhiteIntel** (https://whiteintel.dev) to *Company Research*, in alphabetical position between Vault and Xing.

Free, no-account corporate and offshore ownership research: search a company or person and get a cited ownership graph — officers, parent/subsidiary chains and beneficial owners — fused across 31 public registries (UK Companies House, GLEIF, ICIJ Offshore Leaks, OpenSanctions, SEC EDGAR, OpenOwnership and others), plus OFAC/EU/UN/UK sanctions screening.

Relevant to this list because it covers the gap between per-registry lookups and paid platforms like Bureau van Dijk (already listed): one query resolves the same entity across sources, and every claim links back to its source record. Also exposed over MCP, so it can be queried directly by AI agents/assistants.

Anonymous free tier — no signup required to try it.