### PR TITLE
Add Domain Hunter to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@ algorithms, knowledgebase and AI technology.
 * [DNSViz](https://dnsviz.net)
 * [Domain Crawler](https://www.domaincrawler.com)
 * [Domain Dossier](https://centralops.net/co/DomainDossier.aspx)
+* [Domain Hunter](https://github.com/WhiteBite/Domain-Hunter) - Free, open-source, 100% client-side bulk domain availability checker and name generator: checks up to 3,000 names across 148 TLD zones by calling registry RDAP endpoints directly from the browser (no servers, no API keys, no tracking), with DNS-over-HTTPS corroboration for low-trust ccTLDs, live registrar prices with 3-year TCO, and CSV/Markdown export. MIT. ([live demo](https://whitebite.github.io/Domain-Hunter/))
 * [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) - Aggregate DNS, WHOIS/RDAP, SSL, subdomains (CT logs + DNS bruteforce), and SPF/DMARC posture in one call. Free tier; MIT.
 * [DomainRecon](https://kriztalz.sh/domain-recon/) - Retrieve DNS records, subdomains, SSL certificates and WHOIS / RDAP data for a given website.
 * [Domain Tools](https://whois.domaintools.com) - Whois lookup and domain/ip historical data.


### PR DESCRIPTION
Free, open-source (MIT), 100% client-side bulk domain availability checker and name generator.

- Checks up to 3,000 names across 148 TLD zones by calling registry RDAP endpoints directly from the browser — no servers, no API keys, no tracking
- Honest three-state results (available / probably available / unknown) with DNS-over-HTTPS corroboration for low-trust ccTLDs
- Five name generators, live registrar prices with 3-year TCO, promo-trap detection, CSV/Markdown export
- Live demo: https://whitebite.github.io/Domain-Hunter/

Entry placed alphabetically after Domain Dossier:

`* [Domain Hunter](https://github.com/WhiteBite/Domain-Hunter) - Free, open-source, 100% client-side bulk domain availability checker and name generator: checks up to 3,000 names across 148 TLD zones by calling registry RDAP endpoints directly from the browser (no servers, no API keys, no tracking), with DNS-over-HTTPS corroboration for low-trust ccTLDs, live registrar prices with 3-year TCO, and CSV/Markdown export. MIT. ([live demo](https://whitebite.github.io/Domain-Hunter/))`