### PR TITLE
Add APITube to News

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,7 @@ algorithms, knowledgebase and AI technology.
 * [Agence France-Presse (AFP)](https://www.afp.com)
 * [AllYouCanRead](https://www.allyoucanread.com)
 * [AP](https://hosted.ap.org)
+* [APITube](https://apitube.io) - News API covering 500,000+ sources in 180+ countries and 60+ languages, returning articles as structured JSON with sentiment, entities and topics; free tier of 100 requests/day.
 * [BBC News](https://www.bbc.co.uk/news)
 * [Bing News](https://www.bing.com/news)
 * [CNN](https://edition.cnn.com)


### PR DESCRIPTION
Adds [APITube](https://apitube.io) to the **News** section, inserted alphabetically after AP.

APITube is a news API. It aggregates articles from 500,000+ sources across 180+ countries in 60+ languages and returns them as structured JSON, enriched with sentiment, extracted entities (people, organizations, locations, brands) and topics.

Why it helps people doing OSINT: instead of clicking through the news portals already listed here one by one, you can monitor a name, company, domain or topic across languages in a single query — filtering by keyword, entity, source domain, source country, language, sentiment and date range — and pull historical coverage for a timeline. Results come back as JSON (also CSV/XLSX/Parquet on paid plans), so they drop straight into a spreadsheet or a script.

- Site: https://apitube.io
- Docs: https://docs.apitube.io
- Free tier: 100 requests/day, no card required

Disclosure: I work on APITube, so this is a self-promotional submission.