### PR TITLE
Add Opsis to Username Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ algorithms, knowledgebase and AI technology.
 * [Name Checkup](https://namecheckup.com) - is a search tool that allows you to check the avilability of a givrn username from all over the social media. Inaddition it also sllows you to check the avilability of a given domain name.
 * [NameKetchup](https://nameketchup.com) - checks domain name and username in popular social media sites and platforms.
 * [NexFil](https://github.com/thewhiteh4t/nexfil) - checks username from almost all social network sites.
+* [Opsis](https://useopsis.com) - Username, email or domain search across 700+ source modules, returning linked accounts, breach records and profile metadata. Modules are maintained weekly to prevent false positives and broken results. Paid, account required.
 * [Seekr](https://github.com/seekr-osint/seekr) A multi-purpose all in one toolkit for gathering and managing OSINT-Data with a neat web-interface. Can be used for note taking and username checking.
 * [Sherlock](https://github.com/sherlock-project/sherlock) - Search for a username in multiple platforms/websites.
 * [SherlockEye](https://sherlockeye.io/) - Search for publicly available information connected to a username, uncovering associated profiles and activities across the web.


### PR DESCRIPTION
## Summary

Adds Opsis to the Username Check section, alphabetically between NexFil and Seekr.

Disclosure per the contribution guidelines: I work on Opsis.

Most username and email OSINT tools carry a lot of false positives and quietly
broken modules. Opsis runs a weekly health scan against known-good and known-bad
fixtures for every module. If a result deviates from what is expected, a
maintainer is notified and the module is pulled for repair. That covers 700+
modules across social, gaming, developer and crypto platforms.

A search takes a username, email address or domain and returns linked accounts,
breach and leak records, public records and profile metadata, with anything it
surfaces usable as the seed for the next search.

Paid, from $14.99/month, account required. If you'd like a free Pro plan to
test the platform yourself, email support@useopsis.com.
