### PR TITLE
Add Offendersearch to People Investigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ algorithms, knowledgebase and AI technology.
 * [Kompass](https://www.kompass.com) - Business directory and search.
 * [LERS Portal Directory (Ministry of Cyber Affairs)](https://ministryofcyberaffairs.com/lers) - Directory of platform law-enforcement data-request (LERS) portals (WhatsApp, Google, Apple, Telegram, TikTok, Binance) with eligibility and submission steps for authorised investigators.
 * [Mugshots](https://mugshots.com/)
+* [Offendersearch](https://offendersearch.app) - Free. Search all 58 US state, territory and tribal sex-offender registries in one query; scored, de-duplicated results with a link to the official registry record behind each match. Public API + open data + MCP server.
 * [OpenSanctions](https://www.opensanctions.org/search/) - Information on sanctions and public office holders.
 * [PeekYou](https://www.peekyou.com/) - PeekYou offers the ability to search for people with checks done against more sites. Can check for arrest records as well.
 * [Reunion](https://reunion.com) - People search. Limited free info, premium data upsell.


### PR DESCRIPTION
Adds Offendersearch to People Investigations, alphabetically between Mugshots and OpenSanctions and alongside the existing VineLink / Black Book Online entries. One query searches all 58 US state, territory and tribal sex-offender registries and returns scored, de-duplicated results with a link to the official registry record behind each match. Free, with a public API and open data. https://offendersearch.app
