### PR TITLE
Add Text Machine to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,6 +1701,7 @@ algorithms, knowledgebase and AI technology.
 * [SpiderFoot](https://www.spiderfoot.net) - SpiderFoot is an open source intelligence (OSINT) automation platform with over 200 modules for threat intelligence, attack surface monitoring, security assessments and asset discovery.
 * [SpiderSuite](https://github.com/3nock/SpiderSuite) - An advance, cross-platform, GUI web security crawler.
 * [Sub3 Suite](https://github.com/3nock/sub3suite) - A research-grade suite of tools for intelligence gathering & target mapping with both active and passive(100+ modules) intelligence gathering capabilities.
+* [Text Machine](https://textmachine.org/en/text-tools/cipher-identifier) - Identifies an unknown encoded or enciphered string and decodes it in place when no key is needed (Base64, hex, binary, Morse, Baconian, Polybius, A1Z26, Atbash, Caesar), with frequency analysis and automatic Vigenère and substitution solvers for the rest. Runs in the browser, no signup, nothing uploaded.
 * [The Harvester](https://github.com/laramies/theHarvester) - Gather emails, subdomains, hosts, employee names, open ports and banners from different public sources like search engines, PGP key servers and SHODAN computer database.
 * [Unfurl](https://dfir.blog/unfurl/) - Unfurl analyzes and breaks down URLs into useful forensic components for digital investigation.
 * [Waybackurls](https://github.com/tomnomnom/waybackurls) - Fetch all URLs known by the Wayback Machine for a domain.


### PR DESCRIPTION
**Disclosure up front, per the contributing guidelines: I build and maintain Text Machine.**

Adds one entry to **Other Tools**, alphabetically between Sub3 Suite and The Harvester.

### How this helps people doing OSINT

Investigations keep surfacing a string whose encoding nobody knows yet — a payload out of a QR code, a value in a scraped config, a fragment in a chat log or a paste. [Text Machine's cipher identifier](https://textmachine.org/en/text-tools/cipher-identifier) takes that string, tells you what it is, and for everything that needs no key (Base64, hex, binary, Morse, Baconian, Polybius, A1Z26, Atbash, Caesar) prints the plaintext on the same screen instead of sending you off to a second tool. For keyed classical ciphers it reports the index of coincidence and letter-frequency profile and runs automatic Vigenère and substitution solvers.

It runs entirely client-side: no signup, no upload, nothing leaves the browser. That matters when the string is evidence. Same posture as IntelHub and Argos OSINT, already listed.

### Checklist

- Read the awesome manifesto and the contributing guidelines
- Searched for duplicates first — Text Machine is not currently in the list
- One entry, one pull request
- Inserted alphabetically
- Format `[Name](link) - additional information.`, matching neighbouring entries
- No trailing whitespace
