### PR TITLE
Add Logibook to Maritime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1643,6 +1643,7 @@ algorithms, knowledgebase and AI technology.
 
 ## [↑](#-table-of-contents) Maritime
 
+* [Logibook](https://logibook.dataint.net) - Trade and logistics reference covering 250 countries: 58,730 sourced entities across ports, airports, terminals, trade zones and carriers, built from the NGA World Port Index, UN/LOCODE, SMDG terminal and liner code lists, ISO 6346 container codes, UNCTAD liner shipping connectivity and World Bank port throughput. Each port page also shows the nearest airport, city and trade zone with distances. Every figure carries its source and year. Web reference only, no API or bulk download.
 * [Phantom Tide](https://github.com/tg12/phantomtide) - Cross-domain OSINT dashboard combining vessel tracking, airspace activity, official notices, environmental context, and satellite detections for maritime and airspace analysis.
 * [VesselFinder](https://www.vesselfinder.com) - a FREE AIS vessel tracking web site. VesselFinder displays real time ship positions and marine traffic detected by global AIS network.
 


### PR DESCRIPTION
Adds **Logibook** to the Maritime section.

**Disclosure up front, per the contributing guidelines:** I build and run this
site. The list already carries a sister site of mine — DataInt Databook, under
Data and Statistics — so this is a second entry from the same author, for a
different site and a different section. Say the word and I'll withdraw it.

**How it helps someone doing OSINT.** The Maritime section currently has live
vessel tracking (VesselFinder) and a cross-domain dashboard (Phantom Tide) —
both answer "where is this ship right now". Logibook answers the other half:
what the port itself is. NGA World Port Index entries, UN/LOCODE, SMDG terminal
and liner codes, ISO 6346 container codes, channel depths, container throughput
and UNCTAD connectivity — with each figure attributed to its published source
and year.

The part that isn't just a copy of those registries: every port page also lists
the **nearest airport, city and trade zone with distances**. That join needs
UN/LOCODE against NGA WPI against World Bank trade-zone data, and it's the kind
of question that comes up when you're working out how cargo actually moved.

**What it is not:** no API, no bulk download, no login. It's a web reference —
you read it, you don't ingest it. If the list leans toward tooling you can
script against, that's a fair reason to pass.

Checks: entry inserted alphabetically (Logibook before Phantom Tide), format
matches `[Name](link) - description`, single-purpose PR, no trailing
whitespace. The 58,730 figure and the source list were read off the live site
today.
