### PR TITLE
Remove hijacked and parked domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,6 @@ algorithms, knowledgebase and AI technology.
 * [grep.app](https://grep.app/) - Searches code from the entire github public repositories for a given specific string or using regular expression.
 * [NerdyData](https://nerdydata.com) - Search engine for source code.
 * [PublicWWW](https://publicwww.com/)
-* [Reposearch](https://codefinder.org/)
 * [SearchCode](https://searchcode.com) - Help find real world examples of functions, API's and libraries across 10+ sources.
 * [Sourcebot](https://www.sourcebot.dev/) - Index thousands of repos on your machine and search through them in a fast, powerful, and modern web interface.
 * [SourceGraph](https://sourcegraph.com/search) - Search code from millions of open source repositories.
@@ -922,7 +921,6 @@ algorithms, knowledgebase and AI technology.
 * [aa419 Fake Sites Database](https://db.aa419.org/fakebankslist.php) - The site lists fraudulent websites, such as fake banks and online scams, identified by the Artists Against 419 community.
 * [Accuranker](https://www.accuranker.com)
 * [ahrefs](https://ahrefs.com) - A tool for backlink research, organic traffic research, keyword research, content marketing & more.
-* [Argos OSINT](https://argos-osint.com) - Free Spanish-language OSINT platform: 31 client-side tools + 7 step-by-step guides + 10 curated OSINT prompts for Claude/LLM. Covers WHOIS/RDAP, DoH DNS, subdomain enumeration (crt.sh), unified domain dashboard, IP geolocation, IP reputation via Shodan InternetDB, email header analyzer (SPF/DKIM/DMARC), SPF/DMARC auditor, pwned password check via HIBP k-anonymity, EXIF and PDF metadata analyzers, reverse image search aggregator, Wayback lookup, username finder across 50+ platforms, WhatsApp chat analyzer, JWT decoder, regex/color/UA parser/QR/base64/hash/URL cleaner. No signup, PWA installable, all processing in-browser.
 * [Azure Tenant Resolution by PingCastle](https://tenantresolution.pingcastle.com) - Search for Azure Tenant using its domain name or its ID
 * [Bgpview.io](https://bgpview.io) - The website bgpview.io allows you to look up detailed information about ASNs, IPs, and BGP routes on the internet.
 * [Bing Webmaster Tools](https://www.bing.com/toolbox/webmaster)
@@ -1073,7 +1071,6 @@ algorithms, knowledgebase and AI technology.
 * [Google Image](https://images.google.com)
 * [Google Lens](https://lens.google.com/)
 * [Image Identification Project](https://www.imageidentify.com)
-* [Image Raider](https://www.imageraider.com) - is our reverse image search tool for completing individual searches. When you upload an image to this page, we'll scour the internet to find its source and all of the other pages where it has been posted.
 * [KartaVision](https://kartavision.com/) - search engine for KartaView imagery. It supports natural-language search and search by image
 * [Lenso.ai](https://lenso.ai) - Reverse image search tool with facial recognition, created for finding people, similar images, copies of photos, identical places and more.
 * [Lycos Image Search](https://search.lycos.com)
@@ -1114,7 +1111,6 @@ algorithms, knowledgebase and AI technology.
 * [AudienceCue](https://audiencecue.com/en/tools/youtube-comment-downloader) - Downloads the latest public YouTube video or Shorts comments as CSV for research workflows.
 * [Bing Videos](https://www.bing.com/?scope=video)
 * [Clarify](https://clarify.io)
-* [Clip Blast](https://www.clipblast.com)
 * [DailyMotion](https://www.dailymotion.com)
 * [Deturl](https://deturl.com) - Download a YouTube video from any web page.
 * [DownloadHelper](https://www.downloadhelper.net) - Download any video from any websites, it just works!
@@ -1279,12 +1275,10 @@ algorithms, knowledgebase and AI technology.
 * [Google News Print Archive](https://news.google.com/newspapers)
 * [HeadlineSpot](https://www.headlinespot.com)
 * [Itar-Tass](https://www.itar-tass.com)
-* [List of Newspapers.com](https://www.listofnewspapers.com)
 * [MagPortal](https://www.magportal.com)
 * [News Map](https://newsmap.jp)
 * [News Now](https://www.newsnow.co.uk)
 * [Newseum - Today Front Pages](https://www.newseum.org/todaysfrontpages)
-* [Newslink](https://www.newslink.org)
 * [NewsLookup](https://www.newslookup.com)
 * [Newspaper Map](https://newspapermap.com)
 * [Newspaperindex](https://www.newspaperindex.com)
@@ -1410,12 +1404,10 @@ algorithms, knowledgebase and AI technology.
 * [Bridge.Suumitsu](https://bridge.suumitsu.eu)
 * [ChangeDetection.io](https://changedetection.io)
 * [ChangeDetection.io Open Source](https://github.com/dgtlmoon/changedetection.io)
-* [ChangeDetect](https://www.changedetect.com)
 * [ChangeDetection](https://www.changedetection.com)
 * [Deltafeed](https://bitreading.com/deltafeed)
 * [DiggReader](https://digg.com/login?next=%2Freader)
 * [FeedBooster](https://www.qsensei.com)
-* [Feederator](https://www.feederator.org)
 * [Feed Exileed](https://feed.exileed.com)
 * [Feed Filter Maker](https://feed.janicek.co)
 * [Feedly](https://www.feedly.com)
@@ -1433,7 +1425,6 @@ algorithms, knowledgebase and AI technology.
 * [Reeder](https://reederapp.com)
 * [RSS Bridge](https://bridge.suumitsu.eu)
 * [RSS Feed Reader](https://chrome.google.com/webstore/detail/rss-feed-reader/pnjaodmkngahhkoihejjehlcdlnohgmp)
-* [RSS Micro](https://www.rssmicro.com)
 * [RSS Search Engine](https://ctrlq.org/rss)
 * [RSS Search Hub](https://www.rsssearchhub.com)
 * [RSSOwl](https://www.rssowl.org)
@@ -1547,7 +1538,6 @@ algorithms, knowledgebase and AI technology.
 * [Quadrigram](https://www.quadrigram.com)
 * [Raphael](https://dmitrybaranovskiy.github.io/raphael)
 * [RAW](https://raw.densitydesign.org)
-* [Shanti Interactive](https://www.viseyes.org)
 * [Snappa](https://snappa.io)
 * [StoryMap](https://storymap.knightlab.com)
 * [Tableau Public](https://public.tableau.com)
@@ -1763,7 +1753,6 @@ algorithms, knowledgebase and AI technology.
 * [OSINTCurious](https://osintcurio.us/)
 * [Sector035](https://sector035.nl/)
 * [Skopenow](https://www.skopenow.com/news)
-* [Sleuth For The Truth](https://sleuthforthetruth.com/)
 * [Social Links](https://blog.sociallinks.io/)
 
 ## [↑](#-table-of-contents) OSINT RSS Feeds


### PR DESCRIPTION
These 11 domains have been hijacked, parked, or sold to unrelated parties. **Every one still returns HTTP 200**, so automated link checkers pass them — which is likely why they've survived in the list.

Six now serve gambling or pirated-sports-streaming content to people who click them expecting an OSINT tool.

| Entry | Domain now resolves to |
|---|---|
| Argos OSINT | `argos-osint.com — This website is for sale!` (Sedo parking) |
| Reposearch | `PRABUJITU \| Power Of Zeus X1000` — Indonesian slot gambling |
| ChangeDetect | 301 → `zenbunnichocolate.com`, titled `Mabosplay` — gambling |
| RSS Micro | 301 → `nine-casinoit.it` — *"Migliori Casino non AAMS Agosto 2026"* |
| Clip Blast | 301 → `cakhiatvxttbd.tv` — pirated football streaming |
| Shanti Interactive | 301 → `xoilaczba.tv` — pirated football streaming |
| Newslink | Korean 주소모음 link-farm aggregator |
| List of Newspapers.com | Parking page, *"This domain is for sale"* |
| Sleuth For The Truth | 302 → `expireddomains.com` marketplace listing |
| Image Raider | → `bluegrass.ai` — unrelated ad-analytics product |
| Feederator | → `browserlingapp.com` — unrelated product |

**Argos OSINT is worth a look first.** It carries one of the longest descriptions in the file — a detailed feature list, so a fairly recent addition — and the domain is already parked for sale.

Each of these verifies in one click: open the link and check where it lands.

I checked these while auditing the list's links generally; I've kept this PR to the hijacked/parked cases only, since those seem the most worth acting on — a curated list is a trust surface, and a squatted domain is worse than a plain 404 precisely because it looks like it works.

Happy to follow up with the plain dead links (404s and NXDOMAINs) separately if that would be useful.
