### PR TITLE
Fix two broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ algorithms, knowledgebase and AI technology.
 * [eyedex](https://www.eyedex.org/) - Open directory search engine.
 * [de digger](https://www.dedigger.com/) - is a website that allows you to find any types of files that are publicly available in a Google Drive.
 * [Filesec.io](https://filesec.io/) - Central resource cataloging malicious file extensions, their risks, OS and mitigations.
-* [Find Security Contacts] https://findsecuritycontacts.com - Public index listing security contacts (emails, policies, etc.) extracted from domains security.txt files.
+* [Find Security Contacts](https://findsecuritycontacts.com) - Public index listing security contacts (emails, policies, etc.) extracted from domains security.txt files.
 * [Meawfy](https://meawfy.com/) - Advanced Mega.nz File Search Engine. Search and discover files from Mega.nz with our intelligent crawler technology. Access over 9 million indexed files instantly.
 * [NAPALM FTP Indexer](https://www.searchftps.net/)
 * [ODCrawler](https://odcrawler.xyz/) - A search engine for open directories. Find millions of publicly available files!
@@ -724,7 +724,7 @@ algorithms, knowledgebase and AI technology.
 * [Mugshots](https://mugshots.com/)
 * [Offendersearch](https://offendersearch.app) - Free. Search all 58 US state, territory and tribal sex-offender registries in one query; scored, de-duplicated results with a link to the official registry record behind each match. Public API + open data + MCP server.
 * [OpenSanctions](https://www.opensanctions.org/search/) - Information on sanctions and public office holders.
-* [PeekYou](https://www.peekyou.com/) - PeekYou offers the ability to search for people with checks done against more sites. Can check for arrest records as well.
+* [PeekYou](https://peekyou.com/) - PeekYou offers the ability to search for people with checks done against more sites. Can check for arrest records as well.
 * [Reunion](https://reunion.com) - People search. Limited free info, premium data upsell.
 * [Socialcatfish](https://socialcatfish.com/) - Superextensive people search which works worldwide. Searches are done from 200 Billion records.
 * [SearchBug](https://www.searchbug.com) - People search. Limited free info, premium data upsell.


### PR DESCRIPTION
﻿Two links that are broken in ways a link checker would not catch.

**1. Find Security Contacts — missing parentheses, so the link never renders**

```diff
-* [Find Security Contacts] https://findsecuritycontacts.com - Public index listing...
+* [Find Security Contacts](https://findsecuritycontacts.com) - Public index listing...
```

Currently displays as literal text `[Find Security Contacts] https://...` rather than a link. The site itself is fine — only the markdown is wrong.

**2. PeekYou — `www.` host has no DNS record**

```diff
-* [PeekYou](https://www.peekyou.com/) - ...
+* [PeekYou](https://peekyou.com/) - ...
```

`www.peekyou.com` returns NXDOMAIN (confirmed against both Google and Cloudflare DNS); the apex `peekyou.com` resolves and serves the site. Same destination, working hostname.

Both are one-line changes and the sites remain useful, so this is a fix rather than a removal.
