### PR TITLE
Add AI DECISIONS Wallet Checker (Other Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1654,6 +1654,7 @@ algorithms, knowledgebase and AI technology.
 ## [↑](#-table-of-contents) Other Tools
 
 * [aadinternals](https://aadinternals.com/osint) - Provides tools and insights for advanced analysis and security testing of Azure Active Directory (AAD) and Microsoft 365.
+* [AI DECISIONS Wallet Checker](https://aidecisions.ai/check) - Free multi-chain crypto wallet screening (Ethereum, Bitcoin, Tron, Base, Arbitrum, Gnosis): sanctions hit, mixer exposure and risk tier; no account required.
 * [ArkhamMirror](https://github.com/mantisfury/ArkhamMirror) - Local-first AI document intelligence with offline RAG, contradiction detection, knowledge graphs, and vision AI table extraction.
 * [Barcode Reader](https://online-barcode-reader.inliteresearch.com) - Decode barcodes in C#, VB, Java, C\C++, Delphi, PHP and other languages.
 * [BeVigil-CLI](https://github.com/Bevigil/BeVigil-OSINT-CLI) - A unified command line interface and python library for using BeVigil OSINT API to search for assets such as subdomains, URLs, applications indexed from mobile applications.


### PR DESCRIPTION
Adds **AI DECISIONS Wallet Checker** to Other Tools (alphabetical, between aadinternals and ArkhamMirror).

Link: https://aidecisions.ai/check

How it helps OSINT: a free, no-account wallet check across six chains (Ethereum, Bitcoin, Tron, Base, Arbitrum, Gnosis) returning a sanctions hit, mixer exposure and a risk tier from a live screening line; labels are built from primary public sources (OFAC SDN, court records, regulator registers) and the label tooling is open source under Apache-2.0.

Disclosure up front: I am the founder of AI DECISIONS, the company behind this tool.