### PR TITLE
Add IGDetective to Social Media Tools > Instagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ algorithms, knowledgebase and AI technology.
 
 * [Dolphin Radar](https://www.dolphinradar.com/web-viewer-for-instagram) - An Instagram Post Viewer lets you view posts, stories, and profiles from public accounts with ease. Free viewer limit: 1.
 * [Iconosquare](https://iconosquare.com)
+* [IGDetective](https://www.igdetective.com) - Public Instagram investigation with no login: anonymous story viewer, a follower tracker showing an account's recent follows/unfollows, and a profile viewer, plus optional continuous tracking with a permanent Story Archive (account required for tracking only).
 * [instagram_monitor](https://github.com/misiektoja/instagram_monitor) - Tool for real-time tracking of Instagram users' activities and profile changes with support for email alerts, CSV logging, showing media in the terminal, anonymous story downloads and more
 * [InstagramPrivSniffer](https://github.com/obitouka/InstagramPrivSniffer) - Views Instagram PRIVATE ACCOUNT'S media without login 😱.
 * [insto](https://github.com/subzeroid/insto) - Interactive OSINT CLI / REPL with 35+ slash-commands: profile + media + followers + dossier + geo-fingerprint (`/where`), shared-followers intersection (`/intersect`), superfan ranking (`/fans`), location search (`/place`), URL→metadata resolution (`/postinfo`), posting-cadence histogram (`/timeline`), Maltego CSV export. Token-based (HikerAPI, no IG account needed → no ban risk) with optional logged-in `aiograpi` backend.


### PR DESCRIPTION
Adds IGDetective (https://www.igdetective.com) under Social Media Tools > Instagram, inserted alphabetically after Iconosquare.

This is a re-submission of #964, which was closed in May for two fair reasons. Both have since been addressed:

1. **Account requirement** — IGDetective now has public tools that work with no account and no Instagram login: an anonymous story viewer (https://www.igdetective.com/instagram-story-viewer), a follower tracker that shows a public account's recent follows and unfollows (https://www.igdetective.com/instagram-follower-tracker), a profile viewer (https://www.igdetective.com/instagram-profile-viewer), a profile-picture viewer and a most-followed list. An account is only needed for continuous tracking and the Story Archive, and the entry says so.
2. **Pricing** — the landing page now shows the price directly ("From $1/day · billed monthly").

How it helps OSINT: public-account SOCMINT with no footprint on the target — who an account recently followed and unfollowed, in order; who it interacts with most; anonymous viewing of public Stories and profile photos.

Disclosure: I work on IGDetective, so this is a self-promotional submission, flagged per CONTRIBUTING.md. If it still isn't a fit for the list, no problem — happy to close.