### PR TITLE
Add Vacato to Domain and IP Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,7 @@ algorithms, knowledgebase and AI technology.
 * [urlQuery](https://urlquery.net)
 * [urlscan](https://urlscan.io/) -  is a free service to scan and analyse websites.
 * [URLVoid](https://www.urlvoid.com) - Analyzes a website through multiple blacklist engines and online reputation tools to facilitate the detection of fraudulent and malicious websites.
+* [Vacato](https://vacato.io) - Free RDAP domain availability watchlist: scheduled checks + Telegram/email/Slack when status looks available (not a registrar or drop-catcher). Free tier: 10 domains.
 * [Validin](https://app.validin.com/) - Website and API to search current and historical DNS records for free
 * [Verisign](https://dnssec-debugger.verisignlabs.com)
 * [ViewDNS.info](https://viewdns.info)


### PR DESCRIPTION
**Disclosure:** I built Vacato (self-promotional).

Vacato is a free RDAP domain availability watchlist — scheduled checks + Telegram/email/Slack when status looks available. Not a registrar or drop-catcher.

**OSINT fit:** Same Domain and IP Research lane as Domain Hunter (RDAP availability) and CC.LA (domain monitoring). Useful for brand-protection / reclaim watchlists when a target name may lapse — continuous polling + alerts instead of one-shot checks.

- Site: https://vacato.io
- Free tier: 10 domains
- Entry placed alphabetically before Validin

`* [Vacato](https://vacato.io) - Free RDAP domain availability watchlist: scheduled checks + Telegram/email/Slack when status looks available (not a registrar or drop-catcher). Free tier: 10 domains.`

Made with [Cursor](https://cursor.com)